### PR TITLE
2019b more from upstream

### DIFF
--- a/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/gflags/gflags-2.2.2-GCCcore-8.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'gflags'
+version = '2.2.2'
+
+homepage = 'https://github.com/gflags/gflags'
+description = """
+The gflags package contains a C++ library that implements commandline flags
+processing.  It includes built-in support for standard types such as string
+and the ability to define flags in the source file in which they are used.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/gflags/gflags/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=on -DBUILD_STATIC_LIBS=on'
+
+sanity_check_paths = {
+    'files': ['bin/gflags_completions.sh'] +
+             ['lib/%s' % x for x in ['libgflags.%s' % SHLIB_EXT, 'libgflags_nothreads.%s' % SHLIB_EXT,
+                                     'libgflags.a', 'libgflags_nothreads.a']] +
+             ['include/gflags/gflags_completions.h'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/glog/glog-0.4.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/glog/glog-0.4.0-GCCcore-8.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'glog'
+version = '0.4.0'
+
+homepage = 'https://github.com/google/glog'
+description = "A C++ implementation of the Google logging module."
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/google/glog/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['f28359aeba12f30d73d9e4711ef356dc842886968112162bc73002645139c39c']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+
+dependencies = [
+    ('gflags', '2.2.2'),
+    ('libunwind', '1.3.1'),
+]
+
+configopts = '-DBUILD_SHARED_LIBS=ON '
+
+sanity_check_paths = {
+    'files': ['include/glog/logging.h', 'include/glog/raw_logging.h', 'lib/libglog.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/h/hypothesis/hypothesis-4.44.2-GCCcore-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/h/hypothesis/hypothesis-4.44.2-GCCcore-8.3.0-Python-3.7.4.eb
@@ -1,0 +1,33 @@
+# This easyconfig was created by Simon Branford of the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'hypothesis'
+version = '4.44.2'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://github.com/HypothesisWorks/hypothesis"
+description = """Hypothesis is an advanced testing library for Python. It lets you write tests which are parametrized
+ by a source of examples, and then generates simple and comprehensible examples that make your tests fail. This lets
+ you find more bugs in your code with less work."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [('Python', '3.7.4')]
+
+use_pip = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('attrs', '19.3.0', {
+        'modulename': 'attr',
+        'checksums': ['f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72'],
+    }),
+    (name, version, {
+        'checksums': ['0950e663cef6fea90642996a44aa402978657dea47c8a4fb47caae335379668d'],
+    }),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.2.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.2.2-GCCcore-8.3.0.eb
@@ -1,0 +1,32 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Nils Christian <nils.christian@uni.lu>
+# License::   MIT/GPL
+# $Id$
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'libyaml'
+version = '0.2.2'
+
+homepage = 'https://pyyaml.org/wiki/LibYAML'
+
+description = """LibYAML is a YAML parser and emitter written in C."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://pyyaml.org/download/libyaml/']
+sources = ['yaml-%(version)s.tar.gz']
+checksums = ['4a9100ab61047fd9bd395bcef3ce5403365cafd55c1e0d0299cde14958e47be9']
+
+builddependencies = [('binutils', '2.32')]
+
+sanity_check_paths = {
+    'files': ["include/yaml.h", "lib/libyaml.a", "lib/libyaml.%s" % SHLIB_EXT],
+    'dirs': ["lib/pkgconfig"]
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/Pillow/Pillow-6.2.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/Pillow/Pillow-6.2.1-GCCcore-8.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'PythonPackage'
+
+name = 'Pillow'
+version = '6.2.1'
+
+homepage = 'https://pillow.readthedocs.org/'
+description = """Pillow is the 'friendly PIL fork' by Alex Clark and Contributors.
+ PIL is the Python Imaging Library by Fredrik Lundh and Contributors."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['bf4e972a88f8841d8fdc6db1a75e0f8d763e66e3754b03006cbc3854d89f1cb1']
+
+multi_deps = {'Python': ['3.7.4', '2.7.16']}
+
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [
+    ('libjpeg-turbo', '2.0.3'),
+    ('libpng', '1.6.37'),
+    ('zlib', '1.2.11'),
+    ('LibTIFF', '4.0.10'),
+    ('freetype', '2.10.1')
+]
+
+download_dep_fail = True
+use_pip = True
+
+options = {'modulename': 'PIL'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-5.1.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-5.1.2-GCCcore-8.3.0.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'PyYAML'
+version = '5.1.2'
+
+homepage = "https://github.com/yaml/pyyaml"
+description = """PyYAML is a YAML parser and emitter for the Python programming language."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4']
+
+builddependencies = [('binutils', '2.32')]
+
+multi_deps = {'Python': ['3.7.4', '2.7.16']}
+
+dependencies = [
+    ('libyaml', '0.2.2'),
+]
+
+use_pip = True
+download_dep_fail = True
+
+options = {'modulename': 'yaml'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2019.10-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2019.10-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,44 @@
+easyblock = 'PythonBundle'
+
+name = 'SciPy-bundle'
+version = '2019.10'
+versionsuffix = '-Python-3.7.4'
+
+homepage = 'https://python.org/'
+description = "Bundle of Python packages for scientific software"
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': True, 'lowopt': True}
+
+dependencies = [
+    ('Python', '3.7.4'),
+]
+
+use_pip = True
+
+# order is important!
+exts_list = [
+    ('numpy', '1.17.3', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'checksums': ['a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e'],
+    }),
+    ('scipy', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+        'checksums': ['2643cfb46d97b7797d1dbdb6f3c23fe3402904e3c90e6facfe6a9b98d808c1b5'],
+    }),
+    ('mpi4py', '3.0.2', {
+        'source_urls': ['https://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['f8d629d1e3e3b7b89cb99d0e3bc5505e76cc42089829807950d5c56606ed48e0'],
+    }),
+    ('pandas', '0.25.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+        'checksums': ['52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4'],
+    }),
+    ('mpmath', '1.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mpmath/'],
+        'checksums': ['fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2019.10-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2019.10-fosscuda-2019b-Python-3.7.4.eb
@@ -1,0 +1,44 @@
+easyblock = 'PythonBundle'
+
+name = 'SciPy-bundle'
+version = '2019.10'
+versionsuffix = '-Python-3.7.4'
+
+homepage = 'https://python.org/'
+description = "Bundle of Python packages for scientific software"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': True, 'lowopt': True}
+
+dependencies = [
+    ('Python', '3.7.4'),
+]
+
+use_pip = True
+
+# order is important!
+exts_list = [
+    ('numpy', '1.17.3', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/n/numpy/'],
+        'checksums': ['a0678793096205a4d784bd99f32803ba8100f639cf3b932dc63b21621390ea7e'],
+    }),
+    ('scipy', '1.3.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/scipy/'],
+        'checksums': ['2643cfb46d97b7797d1dbdb6f3c23fe3402904e3c90e6facfe6a9b98d808c1b5'],
+    }),
+    ('mpi4py', '3.0.2', {
+        'source_urls': ['https://bitbucket.org/mpi4py/mpi4py/downloads/'],
+        'checksums': ['f8d629d1e3e3b7b89cb99d0e3bc5505e76cc42089829807950d5c56606ed48e0'],
+    }),
+    ('pandas', '0.25.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+        'checksums': ['52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4'],
+    }),
+    ('mpmath', '1.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mpmath/'],
+        'checksums': ['fc17abe05fbab3382b61a123c398508183406fa132e0223874578e20946499f6'],
+    }),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
Builds on #4 

From upstream:
+ `libyaml-0.2.2-GCCcore-8.3.0.eb`
+ `Pillow-6.2.1-GCCcore-8.3.0.eb`
+ `PyYAML-5.1.2-GCCcore-8.3.0.eb`
+ `SciPy-bundle-2019.10-foss-2019b-Python-3.7.4.eb`
+ `SciPy-bundle-2019.10-fosscuda-2019b-Python-3.7.4.eb`

Created by me and now in upstream:
+ `gflags-2.2.2-GCCcore-8.3.0.eb`
+ `glog-0.4.0-GCCcore-8.3.0.eb`
+ `hypothesis-4.44.2-GCCcore-8.3.0-Python-3.7.4.eb`