### PR TITLE
PyTorch 1.3.1

### DIFF
--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.4.8-gcccuda-2019b.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.4.8-gcccuda-2019b.eb
@@ -1,4 +1,4 @@
-easyblock = "MakeCp"
+easyblock = 'MakeCp'
 
 name = 'NCCL'
 version = '2.4.8'

--- a/easybuild/easyconfigs/n/NCCL/NCCL-2.4.8-gcccuda-2019b.eb
+++ b/easybuild/easyconfigs/n/NCCL/NCCL-2.4.8-gcccuda-2019b.eb
@@ -1,0 +1,34 @@
+easyblock = "MakeCp"
+
+name = 'NCCL'
+version = '2.4.8'
+
+homepage = 'https://developer.nvidia.com/nccl'
+description = """The NVIDIA Collective Communications Library (NCCL) implements multi-GPU and multi-node collective
+communication primitives that are performance optimized for NVIDIA GPUs."""
+
+# gcccuda/2019b uses CUDA 10.1
+toolchain = {'name': 'gcccuda', 'version': '2019b'}
+
+local_cuda_version = '10.1'
+
+# Download from https://developer.nvidia.com/nccl/nccl-download (after log in)
+import subprocess as local_subprocess  # NOQA
+local_arch = local_subprocess.check_output(['uname', '-m']).strip()
+if local_arch == 'ppc64le':
+    sources = ['%%(namelower)s_%%(version)s-1+cuda%s_ppc64le.txz' % local_cuda_version]
+    checksums = ['3f4892422298db36ecda032dad9f56266063a89d50a3f0d6c944773855cc66ce']
+else:
+    sources = ['%%(namelower)s_%%(version)s-1+cuda%s_x86_64.txz' % local_cuda_version]
+    checksums = ['7d929345d3af821188d0b88100ae06f644315d92929d4134709c0c5a1a08f5e6']
+
+skipsteps = ['build']
+
+files_to_copy = ['lib', 'include']
+
+sanity_check_paths = {
+    'files': ['lib/libnccl.%s' % SHLIB_EXT, 'lib/libnccl_static.a', 'include/nccl.h'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,304 @@
+easyblock = 'PythonPackage'
+
+name = 'PyTorch'
+version = '1.3.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+local_pytorchthirdpartydir = 'pytorch-%(version)s/third_party'
+local_extract_cmd_pattern = 'tar -C %s/%s --strip-components=1 -xf %%s'
+local_mkdir_and_extract_cmd_pattern = "DIR=%s/%s; mkdir -p $DIR; tar -C $DIR --strip-components=1 -xzf %%s"
+
+source_urls = ['https://github.com/pytorch/pytorch/archive']
+
+# PyTorch pulls in a bunch of submodules that are not releases. We download the submodule revisions from their repos.
+# determine commit of additional sources via https://github.com/pytorch/pytorch/tree/v1.3.1/third_party
+sources = [
+    'v%(version)s.tar.gz',  # PyTorch
+    {
+        'source_urls': ['https://github.com/facebookincubator/gloo/archive'],
+        'download_filename': 'ca528e32fea9ca8f2b16053cff17160290fc84ce.tar.gz',
+        'filename': 'gloo-20190930.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gloo'),
+    },
+    {
+        'source_urls': ['https://github.com/google/googletest/archive'],
+        'download_filename': '2fe3bd994b3189899d93f1d5a881e725e046fdc2.tar.gz',
+        'filename': 'googletest-20180831.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'googletest'),
+    },
+    {
+        'source_urls': ['https://github.com/pybind/pybind11/archive'],
+        'download_filename': '25abf7efba0b2990f5a6dfb0a31bc65c0f2f4d17.tar.gz',
+        'filename': 'pybind11-20190204.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pybind11'),
+    },
+    {
+        'source_urls': ['https://github.com/wjakob/clang-cindex-python3/archive'],
+        'download_filename': '6a00cbc4a9b8e68b71caf7f774b3f9c753ae84d5.tar.gz',
+        'filename': 'clang-cindex-python3-20170330.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pybind11/tools/clang'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/cpuinfo/archive'],
+        'download_filename': '89fe1695edf9ee14c22f815f24bac45577a4f135.tar.gz',
+        'filename': 'cpuinfo-20190117.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'cpuinfo'),
+    },
+    {
+        'source_urls': ['https://github.com/onnx/onnx/archive'],
+        'download_filename': '034921bd574cc84906b7996c07873454b7dd4135.tar.gz',
+        'filename': 'onnx-20190926.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx'),
+    },
+    {
+        'source_urls': ['https://github.com/google/benchmark/archive'],
+        'download_filename': 'e776aa0275e293707b6a0901e0e8d8a8a3679508.tar.gz',
+        'filename': 'benchmark-20180525.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx/third_party/benchmark'),
+    },
+    {
+        'source_urls': ['https://github.com/pybind/pybind11/archive'],
+        'download_filename': '09f082940113661256310e3f4811aa7261a9fa05.tar.gz',
+        'filename': 'pybind11-20170919.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx/third_party/pybind11'),
+    },
+    {
+        'source_urls': ['https://github.com/onnx/onnx-tensorrt/archive'],
+        'download_filename': 'cb3d8066f20e6bca306454934d09d6abd826264a.tar.gz',
+        'filename': 'onnx-tensorrt-20190425.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx-tensorrt'),
+    },
+    {
+        'source_urls': ['https://github.com/google/protobuf/archive'],
+        'download_filename': '48cb18e5c419ddd23d9badcfe4e9df7bde1979b2.tar.gz',
+        'filename': 'protobuf-20180727.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'protobuf'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/pthreadpool/archive'],
+        'download_filename': '13da0b4c21d17f94150713366420baaf1b5a46f4.tar.gz',
+        'filename': 'pthreadpool-20181008.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pthreadpool'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/FXdiv/archive'],
+        'download_filename': 'b742d1143724d646cd0f914646f1240eacf5bd73.tar.gz',
+        'filename': 'FXdiv-20181016.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'FXdiv'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/psimd/archive'],
+        'download_filename': '90a938f30ba414ada2f4b00674ee9631d7d85e19.tar.gz',
+        'filename': 'psimd-20180906.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'psimd'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/FP16/archive'],
+        'download_filename': 'febbb1c163726b5db24bed55cc9dc42529068997.tar.gz',
+        'filename': 'FP16-20181128.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'FP16'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/NNPACK/archive'],
+        'download_filename': 'c039579abe21f5756e0f0e45e8e767adccc11852.tar.gz',
+        'filename': 'NNPACK-20190323.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'NNPACK'),
+    },
+    {
+        'source_urls': ['https://github.com/shibatch/sleef/archive'],
+        'download_filename': '7f523de651585fe25cade462efccca647dcc8d02.tar.gz',
+        'filename': 'sleef-20190730.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'sleef'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/PeachPy/archive'],
+        'download_filename': '07d8fde8ac45d7705129475c0f94ed8925b93473.tar.gz',
+        'filename': 'PeachPy-20180219.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'python-peachpy'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/QNNPACK/archive'],
+        'download_filename': '7d2a4e9931a82adc3814275b6219a03e24e36b4c.tar.gz',
+        'filename': 'QNNPACK-20190828.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'QNNPACK'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/fbgemm/archive'],
+        'download_filename': '7dfeddb5ba976f47471275b2468909dfd9b577e1.tar.gz',
+        'filename': 'fbgemm-20190927.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm'),
+    },
+    {
+        'source_urls': ['https://github.com/asmjit/asmjit/archive'],
+        'download_filename': '4da474ac9aa2689e88d5e40a2f37628f302d7e3c.tar.gz',
+        'filename': 'asmjit-20190814.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm/third_party/asmjit'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/cpuinfo/archive'],
+        'download_filename': 'd5e37adf1406cf899d7d9ec1d317c47506ccb970.tar.gz',
+        'filename': 'cpuinfo-20190201.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm/third_party/cpuinfo'),
+    },
+    {
+        'source_urls': ['https://github.com/google/googletest/archive'],
+        'download_filename': '0fc5466dbb9e623029b1ada539717d10bd45e99e.tar.gz',
+        'filename': 'googletest-20180920.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir,
+                                                              'fbgemm/third_party/googletest'),
+    },
+    {
+        'source_urls': ['https://github.com/google/benchmark/archive'],
+        'download_filename': '505be96ab23056580a3a2315abba048f4428b04e.tar.gz',
+        'filename': 'benchmark-20180606.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'benchmark'),
+    },
+    {
+        'source_urls': ['https://github.com/eigenteam/eigen-git-mirror/archive'],
+        'download_filename': 'd41dc4dd74acce21fb210e7625d5d135751fa9e5.tar.gz',
+        'filename': 'eigen-20190126.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'eigen'),
+    },
+    {
+        'source_urls': ['https://github.com/google/gemmlowp/archive'],
+        'download_filename': '3fb5c176c17c765a3492cd2f0321b0dab712f350.tar.gz',
+        'filename': 'gemmlowp-20181127.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gemmlowp/gemmlowp'),
+    },
+    {
+        'source_urls': ['https://github.com/NVIDIA/nccl/archive'],
+        'download_filename': '7c72dee660e4d055b81721dd6b03e4e1c0a983cf.tar.gz',
+        'filename': 'nccl-20190625.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'nccl/nccl'),
+    },
+    {
+        'source_urls': ['https://github.com/NVlabs/cub/archive'],
+        'download_filename': '285aeebaa34b0e8a7670867a2e66c1a52d998d6a.tar.gz',
+        'filename': 'cub-20170829.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'cub'),
+    },
+    {
+        'source_urls': ['https://github.com/houseroad/foxi/archive'],
+        'download_filename': '8f74bc4df3a4cfc69b1a3eadf62aa29d9961c72d.tar.gz',
+        'filename': 'foxi-20190424.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'foxi'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/ideep/archive'],
+        'download_filename': '78eafa5d231924e3d525d4dc46de880015257618.tar.gz',
+        'filename': 'ideep-20190912.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'ideep'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/tbb/archive'],
+        'download_filename': 'a51a90bc609bb73db8ea13841b5cf7aa4344d4a9.tar.gz',
+        'filename': 'tbb-20181009.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'tbb'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/mkl-dnn/archive'],
+        'download_filename': '0125f28c61c1f822fd48570b4c1066f96fcb9b2e.tar.gz',
+        'filename': 'mkl-dnn-20190905.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'ideep/mkl-dnn'),
+    },
+    # mkl-dnn requires Intel MKL, so download minimal Intel MKL version
+    # actually using imkl as a dependency would be messy due to underlying icc/ifort compilers & impi MPI lib
+    {
+        'source_urls': ['https://github.com/intel/mkl-dnn/releases/download/v0.21'],
+        'filename': 'mklml_lnx_2019.0.5.20190502.tgz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern %
+        (local_pytorchthirdpartydir, 'ideep/mkl-dnn/external/mklml_lnx_2019.0.5.20190502'),
+    },
+]
+patches = [
+    '%(name)s-1.2.0_fix-findAVX.patch',
+    '%(name)s-1.2.0_disable-tests-ppc64le.patch',
+    '%(name)s-%(version)s_fix-missing-sleef_h.patch',
+]
+checksums = [
+    'ab6feb5044f7d36f6e93dce4668d8c593e89d34aca7023fd99a38d215ca9dfc0',  # v1.3.1.tar.gz
+    '1354079f38459bc8f322d1f5808eb5c57059a473e77489e981fb5debeadf0ad0',  # gloo-20190930.tar.gz
+    'd0d447b4feeedca837a0d46a289d4223089b32ac2f84545fa4982755cc8919be',  # googletest-20180831.tar.gz
+    '1a1ccf8779332a7d6d0db9034d42df188867cbaf52eb71d74451f79aa8ce2040',  # pybind11-20190204.tar.gz
+    '828e0d6238e2129a9e08071750dc16ba10e38eacf96f21b8a71e501c2085b282',  # clang-cindex-python3-20170330.tar.gz
+    'b84c49b4bdc12b0e8f1bff365dcefd50e5a2a25eeef8c928aeb2dab9fda4d599',  # cpuinfo-20190117.tar.gz
+    'eaa2d4b70aa0003fdab136ae26b5e0aebabcf6421df7fef69fec9ce005a09586',  # onnx-20190926.tar.gz
+    'c7682e9007ddfd94072647abab3e89ffd9084089460ae47d67060974467b58bf',  # benchmark-20180525.tar.gz
+    '02407529fd8431cf627d45638b4d9a6c02b8aa5bf50d73b8fa12217918c57ff4',  # pybind11-20170919.tar.gz
+    '1a98c6fece7878c88b59ffe651b427c15b4929c801a09655cd14ca44553787c3',  # onnx-tensorrt-20190425.tar.gz
+    'f5a35e17fb07f3b13517264cd17a089636fcbb2912f9df7bef7414058969a8d2',  # protobuf-20180727.tar.gz
+    '90ab4f60ae0e99c0172dd5201dccc6de6c8f384a21b3d959588f4c1e00beec0f',  # pthreadpool-20181008.tar.gz
+    '07625551202a1f35fe5e826669ad495962b26f6a139290e90b321c5996f002ef',  # FXdiv-20181016.tar.gz
+    'afd27417c6df1c85f79a68361055dd3adc292174913c39c1f58b698b9cfd7926',  # psimd-20180906.tar.gz
+    '3e71681e0a67cd28552aa0bbb78ec6a6bd238216df15336dc1326280f7958de2',  # FP16-20181128.tar.gz
+    '2c276e6cc9e3fb7a79bc337662aba738a638975381bac6d393254ec288d6269e',  # NNPACK-20190323.tar.gz
+    '8cb5fae822077ca9cbc14dcc7bba9a3a35ad519284fc5169f9a176672c63860a',  # sleef-20190730.tar.gz
+    '13100c3deed300bbf16f87d8af3539f432462bfef9d38f0c7e3e387dc2e88676',  # PeachPy-20180219.tar.gz
+    '0d752bd75f46ce4d7c6f0a60b0d6c0e5918a7b4683c825284f8db3706dd24f76',  # QNNPACK-20190828.tar.gz
+    'e878fcca2f2c59b7b007da3cc4c15b0af9bbbaacbff60d11dacca55b1b6e56e8',  # fbgemm-20190927.tar.gz
+    'a6de3e1604b46b2e37ae31c0896e90f4962e887e0a3bcf1bd2fb8cc55a5c59cf',  # asmjit-20190814.tar.gz
+    '3f2dc1970f397a0e59db72f9fca6ff144b216895c1d606f6c94a507c1e53a025',  # cpuinfo-20190201.tar.gz
+    'e99b904983d08ac8e9bddb5b0d21196b78ad9499e3c5d12192cee2ddd2b7515c',  # googletest-20180920.tar.gz
+    '0de43b6eaddd356f1d6cd164f73f37faf2f6c96fd684e1f7ea543ce49c1d144e',  # benchmark-20180606.tar.gz
+    '2ec954f18cec50a7063a7358ce555f7e11788a7f6d4e7e597d83687dc2f3b989',  # eigen-20190126.tar.gz
+    'fdd6f08bdb33d33f4df516ffb91730fdb163479c19502cfc983083fd9cf43bfa',  # gemmlowp-20181127.tar.gz
+    'ef8b624ef28e9e2d0e162065932dd2f25de8d6d1dc58df91bd36977e4bc0224c',  # nccl-20190625.tar.gz
+    '7224b03af4acbc54525105bb42e3ecd75c66a3a5b47e8a725ab008467c4109f9',  # cub-20170829.tar.gz
+    'b444b4428adc4befc777d9a1af2fd9bbf5f5a2339913668357196c5133e9cc7b',  # foxi-20190424.tar.gz
+    'b8fb8b4871cc3da4bded01c476957a08f51949c20f834f39f90f9e10811d6dfe',  # ideep-20190912.tar.gz
+    'dc0a8d8d96cb8765782aa6ac1b509ad4db955d9bbb58fa5cc2265f0292756d72',  # tbb-20181009.tar.gz
+    'd16c64ab2ce654f0a21e51f933ae9ee480a8873717d0bd10e0f2a2f658a7095b',  # mkl-dnn-20190905.tar.gz
+    'a936d6b277a33d2a027a024ea8e65df62bd2e162c7ca52c48486ed9d5dc27160',  # mklml_lnx_2019.0.5.20190502.tgz
+    '001c9bf604aebe4b39ccad15332a71130b07b780c539ceca84d6c64cd6fc8a68',  # PyTorch-1.2.0_fix-findAVX.patch
+    'c4183bcb29a8bcbadea0341e93a3a32afdf860aa31331b768e787d899183da92',  # PyTorch-1.2.0_disable-tests-ppc64le.patch
+    '1337647ff64a1208d1e401fc84052d0bc6174b133cec2f3521319cb593f524fa',  # PyTorch-1.3.1_fix-missing-sleef_h.patch
+]
+
+builddependencies = [
+    ('CMake', '3.15.3'),
+    ('hypothesis', '4.44.2', versionsuffix),
+    ('Ninja', '1.9.0'),
+]
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('PyYAML', '5.1.2'),
+    ('MPFR', '4.0.2'),
+    ('GMP', '6.1.2'),
+    ('numactl', '2.0.12'),
+    ('FFmpeg', '4.2.1'),
+    ('gflags', '2.2.2'),
+    ('glog', '0.4.0'),
+    ('Pillow', '6.2.1'),
+]
+
+download_dep_fail = True
+
+prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE=1 '
+prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
+prebuildopts += 'USE_FFMPEG=ON USE_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
+
+preinstallopts = prebuildopts
+
+runtest = 'export PYTHONPATH=%(builddir)s/%(namelower)s-%(version)s/' \
+          'build/lib.linux-%(arch)s-%(pyshortver)s:$PYTHONPATH '
+runtest += '&& export LD_LIBRARY_PATH=%(builddir)s/%(namelower)s-%(version)s/torch/lib64:$LD_LIBRARY_PATH '
+runtest += '&& python test/run_test.py --verbose '
+
+options = {'modulename': 'torch'}
+
+postinstallcmds = ['cp -a %(builddir)s/%(namelower)s-%(version)s/torch/lib*/* %(installdir)s/lib/']
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
@@ -172,12 +172,6 @@ sources = [
         'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gemmlowp/gemmlowp'),
     },
     {
-        'source_urls': ['https://github.com/NVIDIA/nccl/archive'],
-        'download_filename': '7c72dee660e4d055b81721dd6b03e4e1c0a983cf.tar.gz',
-        'filename': 'nccl-20190625.tar.gz',
-        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'nccl/nccl'),
-    },
-    {
         'source_urls': ['https://github.com/NVlabs/cub/archive'],
         'download_filename': '285aeebaa34b0e8a7670867a2e66c1a52d998d6a.tar.gz',
         'filename': 'cub-20170829.tar.gz',
@@ -248,7 +242,6 @@ checksums = [
     '0de43b6eaddd356f1d6cd164f73f37faf2f6c96fd684e1f7ea543ce49c1d144e',  # benchmark-20180606.tar.gz
     '2ec954f18cec50a7063a7358ce555f7e11788a7f6d4e7e597d83687dc2f3b989',  # eigen-20190126.tar.gz
     'fdd6f08bdb33d33f4df516ffb91730fdb163479c19502cfc983083fd9cf43bfa',  # gemmlowp-20181127.tar.gz
-    'ef8b624ef28e9e2d0e162065932dd2f25de8d6d1dc58df91bd36977e4bc0224c',  # nccl-20190625.tar.gz
     '7224b03af4acbc54525105bb42e3ecd75c66a3a5b47e8a725ab008467c4109f9',  # cub-20170829.tar.gz
     'b444b4428adc4befc777d9a1af2fd9bbf5f5a2339913668357196c5133e9cc7b',  # foxi-20190424.tar.gz
     'b8fb8b4871cc3da4bded01c476957a08f51949c20f834f39f90f9e10811d6dfe',  # ideep-20190912.tar.gz

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb
@@ -283,7 +283,7 @@ download_dep_fail = True
 
 prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE=1 '
 prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
-prebuildopts += 'USE_FFMPEG=ON USE_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
+prebuildopts += 'USE_FFMPEG=ON USE_GFLAGS=ON USE_GLOG=ON '
 
 preinstallopts = prebuildopts
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
@@ -172,12 +172,6 @@ sources = [
         'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gemmlowp/gemmlowp'),
     },
     {
-        'source_urls': ['https://github.com/NVIDIA/nccl/archive'],
-        'download_filename': '7c72dee660e4d055b81721dd6b03e4e1c0a983cf.tar.gz',
-        'filename': 'nccl-20190625.tar.gz',
-        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'nccl/nccl'),
-    },
-    {
         'source_urls': ['https://github.com/NVlabs/cub/archive'],
         'download_filename': '285aeebaa34b0e8a7670867a2e66c1a52d998d6a.tar.gz',
         'filename': 'cub-20170829.tar.gz',
@@ -248,7 +242,6 @@ checksums = [
     '0de43b6eaddd356f1d6cd164f73f37faf2f6c96fd684e1f7ea543ce49c1d144e',  # benchmark-20180606.tar.gz
     '2ec954f18cec50a7063a7358ce555f7e11788a7f6d4e7e597d83687dc2f3b989',  # eigen-20190126.tar.gz
     'fdd6f08bdb33d33f4df516ffb91730fdb163479c19502cfc983083fd9cf43bfa',  # gemmlowp-20181127.tar.gz
-    'ef8b624ef28e9e2d0e162065932dd2f25de8d6d1dc58df91bd36977e4bc0224c',  # nccl-20190625.tar.gz
     '7224b03af4acbc54525105bb42e3ecd75c66a3a5b47e8a725ab008467c4109f9',  # cub-20170829.tar.gz
     'b444b4428adc4befc777d9a1af2fd9bbf5f5a2339913668357196c5133e9cc7b',  # foxi-20190424.tar.gz
     'b8fb8b4871cc3da4bded01c476957a08f51949c20f834f39f90f9e10811d6dfe',  # ideep-20190912.tar.gz
@@ -279,6 +272,7 @@ dependencies = [
     ('Pillow', '6.2.1'),
     ('cuDNN', '7.6.4.38'),
     ('magma', '2.5.1'),
+    ('NCCL', '2.4.8'),
 ]
 
 download_dep_fail = True
@@ -287,7 +281,7 @@ prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE
 prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
 prebuildopts += 'USE_FFMPEG=ON USE_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
 prebuildopts += 'CUDNN_LIB_DIR=$EBROOTCUDNN/lib64 CUDNN_INCLUDE_DIR=$EBROOTCUDNN/include '
-prebuildopts += 'TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0 7.2 7.5" '
+prebuildopts += 'USE_SYSTEM_NCCL=1 TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0 7.2 7.5" '
 
 preinstallopts = prebuildopts
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
@@ -281,7 +281,8 @@ prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE
 prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
 prebuildopts += 'USE_FFMPEG=ON USE_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
 prebuildopts += 'CUDNN_LIB_DIR=$EBROOTCUDNN/lib64 CUDNN_INCLUDE_DIR=$EBROOTCUDNN/include '
-prebuildopts += 'USE_SYSTEM_NCCL=1 TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0 7.2 7.5" '
+prebuildopts += 'USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=$EBROOTNCCL/include '
+prebuildopts += 'TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0 7.2 7.5" '
 
 preinstallopts = prebuildopts
 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb
@@ -1,0 +1,308 @@
+easyblock = 'PythonPackage'
+
+name = 'PyTorch'
+version = '1.3.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+local_pytorchthirdpartydir = 'pytorch-%(version)s/third_party'
+local_extract_cmd_pattern = 'tar -C %s/%s --strip-components=1 -xf %%s'
+local_mkdir_and_extract_cmd_pattern = "DIR=%s/%s; mkdir -p $DIR; tar -C $DIR --strip-components=1 -xzf %%s"
+
+source_urls = ['https://github.com/pytorch/pytorch/archive']
+
+# PyTorch pulls in a bunch of submodules that are not releases. We download the submodule revisions from their repos.
+# determine commit of additional sources via https://github.com/pytorch/pytorch/tree/v1.3.1/third_party
+sources = [
+    'v%(version)s.tar.gz',  # PyTorch
+    {
+        'source_urls': ['https://github.com/facebookincubator/gloo/archive'],
+        'download_filename': 'ca528e32fea9ca8f2b16053cff17160290fc84ce.tar.gz',
+        'filename': 'gloo-20190930.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gloo'),
+    },
+    {
+        'source_urls': ['https://github.com/google/googletest/archive'],
+        'download_filename': '2fe3bd994b3189899d93f1d5a881e725e046fdc2.tar.gz',
+        'filename': 'googletest-20180831.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'googletest'),
+    },
+    {
+        'source_urls': ['https://github.com/pybind/pybind11/archive'],
+        'download_filename': '25abf7efba0b2990f5a6dfb0a31bc65c0f2f4d17.tar.gz',
+        'filename': 'pybind11-20190204.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pybind11'),
+    },
+    {
+        'source_urls': ['https://github.com/wjakob/clang-cindex-python3/archive'],
+        'download_filename': '6a00cbc4a9b8e68b71caf7f774b3f9c753ae84d5.tar.gz',
+        'filename': 'clang-cindex-python3-20170330.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pybind11/tools/clang'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/cpuinfo/archive'],
+        'download_filename': '89fe1695edf9ee14c22f815f24bac45577a4f135.tar.gz',
+        'filename': 'cpuinfo-20190117.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'cpuinfo'),
+    },
+    {
+        'source_urls': ['https://github.com/onnx/onnx/archive'],
+        'download_filename': '034921bd574cc84906b7996c07873454b7dd4135.tar.gz',
+        'filename': 'onnx-20190926.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx'),
+    },
+    {
+        'source_urls': ['https://github.com/google/benchmark/archive'],
+        'download_filename': 'e776aa0275e293707b6a0901e0e8d8a8a3679508.tar.gz',
+        'filename': 'benchmark-20180525.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx/third_party/benchmark'),
+    },
+    {
+        'source_urls': ['https://github.com/pybind/pybind11/archive'],
+        'download_filename': '09f082940113661256310e3f4811aa7261a9fa05.tar.gz',
+        'filename': 'pybind11-20170919.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx/third_party/pybind11'),
+    },
+    {
+        'source_urls': ['https://github.com/onnx/onnx-tensorrt/archive'],
+        'download_filename': 'cb3d8066f20e6bca306454934d09d6abd826264a.tar.gz',
+        'filename': 'onnx-tensorrt-20190425.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'onnx-tensorrt'),
+    },
+    {
+        'source_urls': ['https://github.com/google/protobuf/archive'],
+        'download_filename': '48cb18e5c419ddd23d9badcfe4e9df7bde1979b2.tar.gz',
+        'filename': 'protobuf-20180727.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'protobuf'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/pthreadpool/archive'],
+        'download_filename': '13da0b4c21d17f94150713366420baaf1b5a46f4.tar.gz',
+        'filename': 'pthreadpool-20181008.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'pthreadpool'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/FXdiv/archive'],
+        'download_filename': 'b742d1143724d646cd0f914646f1240eacf5bd73.tar.gz',
+        'filename': 'FXdiv-20181016.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'FXdiv'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/psimd/archive'],
+        'download_filename': '90a938f30ba414ada2f4b00674ee9631d7d85e19.tar.gz',
+        'filename': 'psimd-20180906.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'psimd'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/FP16/archive'],
+        'download_filename': 'febbb1c163726b5db24bed55cc9dc42529068997.tar.gz',
+        'filename': 'FP16-20181128.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'FP16'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/NNPACK/archive'],
+        'download_filename': 'c039579abe21f5756e0f0e45e8e767adccc11852.tar.gz',
+        'filename': 'NNPACK-20190323.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'NNPACK'),
+    },
+    {
+        'source_urls': ['https://github.com/shibatch/sleef/archive'],
+        'download_filename': '7f523de651585fe25cade462efccca647dcc8d02.tar.gz',
+        'filename': 'sleef-20190730.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'sleef'),
+    },
+    {
+        'source_urls': ['https://github.com/Maratyszcza/PeachPy/archive'],
+        'download_filename': '07d8fde8ac45d7705129475c0f94ed8925b93473.tar.gz',
+        'filename': 'PeachPy-20180219.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'python-peachpy'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/QNNPACK/archive'],
+        'download_filename': '7d2a4e9931a82adc3814275b6219a03e24e36b4c.tar.gz',
+        'filename': 'QNNPACK-20190828.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'QNNPACK'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/fbgemm/archive'],
+        'download_filename': '7dfeddb5ba976f47471275b2468909dfd9b577e1.tar.gz',
+        'filename': 'fbgemm-20190927.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm'),
+    },
+    {
+        'source_urls': ['https://github.com/asmjit/asmjit/archive'],
+        'download_filename': '4da474ac9aa2689e88d5e40a2f37628f302d7e3c.tar.gz',
+        'filename': 'asmjit-20190814.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm/third_party/asmjit'),
+    },
+    {
+        'source_urls': ['https://github.com/pytorch/cpuinfo/archive'],
+        'download_filename': 'd5e37adf1406cf899d7d9ec1d317c47506ccb970.tar.gz',
+        'filename': 'cpuinfo-20190201.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir, 'fbgemm/third_party/cpuinfo'),
+    },
+    {
+        'source_urls': ['https://github.com/google/googletest/archive'],
+        'download_filename': '0fc5466dbb9e623029b1ada539717d10bd45e99e.tar.gz',
+        'filename': 'googletest-20180920.tar.gz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern % (local_pytorchthirdpartydir,
+                                                              'fbgemm/third_party/googletest'),
+    },
+    {
+        'source_urls': ['https://github.com/google/benchmark/archive'],
+        'download_filename': '505be96ab23056580a3a2315abba048f4428b04e.tar.gz',
+        'filename': 'benchmark-20180606.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'benchmark'),
+    },
+    {
+        'source_urls': ['https://github.com/eigenteam/eigen-git-mirror/archive'],
+        'download_filename': 'd41dc4dd74acce21fb210e7625d5d135751fa9e5.tar.gz',
+        'filename': 'eigen-20190126.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'eigen'),
+    },
+    {
+        'source_urls': ['https://github.com/google/gemmlowp/archive'],
+        'download_filename': '3fb5c176c17c765a3492cd2f0321b0dab712f350.tar.gz',
+        'filename': 'gemmlowp-20181127.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'gemmlowp/gemmlowp'),
+    },
+    {
+        'source_urls': ['https://github.com/NVIDIA/nccl/archive'],
+        'download_filename': '7c72dee660e4d055b81721dd6b03e4e1c0a983cf.tar.gz',
+        'filename': 'nccl-20190625.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'nccl/nccl'),
+    },
+    {
+        'source_urls': ['https://github.com/NVlabs/cub/archive'],
+        'download_filename': '285aeebaa34b0e8a7670867a2e66c1a52d998d6a.tar.gz',
+        'filename': 'cub-20170829.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'cub'),
+    },
+    {
+        'source_urls': ['https://github.com/houseroad/foxi/archive'],
+        'download_filename': '8f74bc4df3a4cfc69b1a3eadf62aa29d9961c72d.tar.gz',
+        'filename': 'foxi-20190424.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'foxi'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/ideep/archive'],
+        'download_filename': '78eafa5d231924e3d525d4dc46de880015257618.tar.gz',
+        'filename': 'ideep-20190912.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'ideep'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/tbb/archive'],
+        'download_filename': 'a51a90bc609bb73db8ea13841b5cf7aa4344d4a9.tar.gz',
+        'filename': 'tbb-20181009.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'tbb'),
+    },
+    {
+        'source_urls': ['https://github.com/intel/mkl-dnn/archive'],
+        'download_filename': '0125f28c61c1f822fd48570b4c1066f96fcb9b2e.tar.gz',
+        'filename': 'mkl-dnn-20190905.tar.gz',
+        'extract_cmd': local_extract_cmd_pattern % (local_pytorchthirdpartydir, 'ideep/mkl-dnn'),
+    },
+    # mkl-dnn requires Intel MKL, so download minimal Intel MKL version
+    # actually using imkl as a dependency would be messy due to underlying icc/ifort compilers & impi MPI lib
+    {
+        'source_urls': ['https://github.com/intel/mkl-dnn/releases/download/v0.21'],
+        'filename': 'mklml_lnx_2019.0.5.20190502.tgz',
+        'extract_cmd': local_mkdir_and_extract_cmd_pattern %
+        (local_pytorchthirdpartydir, 'ideep/mkl-dnn/external/mklml_lnx_2019.0.5.20190502'),
+    },
+]
+patches = [
+    '%(name)s-1.2.0_fix-findAVX.patch',
+    '%(name)s-1.2.0_disable-tests-ppc64le.patch',
+    '%(name)s-%(version)s_fix-missing-sleef_h.patch',
+]
+checksums = [
+    'ab6feb5044f7d36f6e93dce4668d8c593e89d34aca7023fd99a38d215ca9dfc0',  # v1.3.1.tar.gz
+    '1354079f38459bc8f322d1f5808eb5c57059a473e77489e981fb5debeadf0ad0',  # gloo-20190930.tar.gz
+    'd0d447b4feeedca837a0d46a289d4223089b32ac2f84545fa4982755cc8919be',  # googletest-20180831.tar.gz
+    '1a1ccf8779332a7d6d0db9034d42df188867cbaf52eb71d74451f79aa8ce2040',  # pybind11-20190204.tar.gz
+    '828e0d6238e2129a9e08071750dc16ba10e38eacf96f21b8a71e501c2085b282',  # clang-cindex-python3-20170330.tar.gz
+    'b84c49b4bdc12b0e8f1bff365dcefd50e5a2a25eeef8c928aeb2dab9fda4d599',  # cpuinfo-20190117.tar.gz
+    'eaa2d4b70aa0003fdab136ae26b5e0aebabcf6421df7fef69fec9ce005a09586',  # onnx-20190926.tar.gz
+    'c7682e9007ddfd94072647abab3e89ffd9084089460ae47d67060974467b58bf',  # benchmark-20180525.tar.gz
+    '02407529fd8431cf627d45638b4d9a6c02b8aa5bf50d73b8fa12217918c57ff4',  # pybind11-20170919.tar.gz
+    '1a98c6fece7878c88b59ffe651b427c15b4929c801a09655cd14ca44553787c3',  # onnx-tensorrt-20190425.tar.gz
+    'f5a35e17fb07f3b13517264cd17a089636fcbb2912f9df7bef7414058969a8d2',  # protobuf-20180727.tar.gz
+    '90ab4f60ae0e99c0172dd5201dccc6de6c8f384a21b3d959588f4c1e00beec0f',  # pthreadpool-20181008.tar.gz
+    '07625551202a1f35fe5e826669ad495962b26f6a139290e90b321c5996f002ef',  # FXdiv-20181016.tar.gz
+    'afd27417c6df1c85f79a68361055dd3adc292174913c39c1f58b698b9cfd7926',  # psimd-20180906.tar.gz
+    '3e71681e0a67cd28552aa0bbb78ec6a6bd238216df15336dc1326280f7958de2',  # FP16-20181128.tar.gz
+    '2c276e6cc9e3fb7a79bc337662aba738a638975381bac6d393254ec288d6269e',  # NNPACK-20190323.tar.gz
+    '8cb5fae822077ca9cbc14dcc7bba9a3a35ad519284fc5169f9a176672c63860a',  # sleef-20190730.tar.gz
+    '13100c3deed300bbf16f87d8af3539f432462bfef9d38f0c7e3e387dc2e88676',  # PeachPy-20180219.tar.gz
+    '0d752bd75f46ce4d7c6f0a60b0d6c0e5918a7b4683c825284f8db3706dd24f76',  # QNNPACK-20190828.tar.gz
+    'e878fcca2f2c59b7b007da3cc4c15b0af9bbbaacbff60d11dacca55b1b6e56e8',  # fbgemm-20190927.tar.gz
+    'a6de3e1604b46b2e37ae31c0896e90f4962e887e0a3bcf1bd2fb8cc55a5c59cf',  # asmjit-20190814.tar.gz
+    '3f2dc1970f397a0e59db72f9fca6ff144b216895c1d606f6c94a507c1e53a025',  # cpuinfo-20190201.tar.gz
+    'e99b904983d08ac8e9bddb5b0d21196b78ad9499e3c5d12192cee2ddd2b7515c',  # googletest-20180920.tar.gz
+    '0de43b6eaddd356f1d6cd164f73f37faf2f6c96fd684e1f7ea543ce49c1d144e',  # benchmark-20180606.tar.gz
+    '2ec954f18cec50a7063a7358ce555f7e11788a7f6d4e7e597d83687dc2f3b989',  # eigen-20190126.tar.gz
+    'fdd6f08bdb33d33f4df516ffb91730fdb163479c19502cfc983083fd9cf43bfa',  # gemmlowp-20181127.tar.gz
+    'ef8b624ef28e9e2d0e162065932dd2f25de8d6d1dc58df91bd36977e4bc0224c',  # nccl-20190625.tar.gz
+    '7224b03af4acbc54525105bb42e3ecd75c66a3a5b47e8a725ab008467c4109f9',  # cub-20170829.tar.gz
+    'b444b4428adc4befc777d9a1af2fd9bbf5f5a2339913668357196c5133e9cc7b',  # foxi-20190424.tar.gz
+    'b8fb8b4871cc3da4bded01c476957a08f51949c20f834f39f90f9e10811d6dfe',  # ideep-20190912.tar.gz
+    'dc0a8d8d96cb8765782aa6ac1b509ad4db955d9bbb58fa5cc2265f0292756d72',  # tbb-20181009.tar.gz
+    'd16c64ab2ce654f0a21e51f933ae9ee480a8873717d0bd10e0f2a2f658a7095b',  # mkl-dnn-20190905.tar.gz
+    'a936d6b277a33d2a027a024ea8e65df62bd2e162c7ca52c48486ed9d5dc27160',  # mklml_lnx_2019.0.5.20190502.tgz
+    '001c9bf604aebe4b39ccad15332a71130b07b780c539ceca84d6c64cd6fc8a68',  # PyTorch-1.2.0_fix-findAVX.patch
+    'c4183bcb29a8bcbadea0341e93a3a32afdf860aa31331b768e787d899183da92',  # PyTorch-1.2.0_disable-tests-ppc64le.patch
+    '1337647ff64a1208d1e401fc84052d0bc6174b133cec2f3521319cb593f524fa',  # PyTorch-1.3.1_fix-missing-sleef_h.patch
+]
+
+builddependencies = [
+    ('CMake', '3.15.3'),
+    ('hypothesis', '4.44.2', versionsuffix),
+    ('Ninja', '1.9.0'),
+]
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('PyYAML', '5.1.2'),
+    ('MPFR', '4.0.2'),
+    ('GMP', '6.1.2'),
+    ('numactl', '2.0.12'),
+    ('FFmpeg', '4.2.1'),
+    ('gflags', '2.2.2'),
+    ('glog', '0.4.0'),
+    ('Pillow', '6.2.1'),
+    ('cuDNN', '7.6.4.38'),
+    ('magma', '2.5.1'),
+]
+
+download_dep_fail = True
+
+prebuildopts = 'PYTORCH_BUILD_VERSION=%(version)s PYTORCH_BUILD_NUMBER=1 VERBOSE=1 '
+prebuildopts += 'LDFLAGS="$LDFLAGS -ldl" '
+prebuildopts += 'USE_FFMPEG=ON USE_IBVERBS=1 USE_GFLAGS=ON USE_GLOG=ON '
+prebuildopts += 'CUDNN_LIB_DIR=$EBROOTCUDNN/lib64 CUDNN_INCLUDE_DIR=$EBROOTCUDNN/include '
+prebuildopts += 'TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0 7.2 7.5" '
+
+preinstallopts = prebuildopts
+
+runtest = 'export PYTHONPATH=%(builddir)s/%(namelower)s-%(version)s/' \
+          'build/lib.linux-%(arch)s-%(pyshortver)s:$PYTHONPATH '
+runtest += '&& export LD_LIBRARY_PATH=%(builddir)s/%(namelower)s-%(version)s/torch/lib64:$LD_LIBRARY_PATH '
+runtest += '&& python test/run_test.py --verbose '
+
+options = {'modulename': 'torch'}
+
+postinstallcmds = ['cp -a %(builddir)s/%(namelower)s-%(version)s/torch/lib*/* %(installdir)s/lib/']
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1_fix-missing-sleef_h.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.3.1_fix-missing-sleef_h.patch
@@ -1,0 +1,13 @@
+Remove ATen test that fails to find sleef.h during build on Intel systems when -march=native is set
+Fix from https://github.com/pytorch/pytorch/issues/26555#issuecomment-533801098
+Patch created by Simon Branford of the BEAR Software team at the University of Birmingham
+--- aten/src/ATen/test/CMakeLists.txt.orig	2019-11-17 10:59:54.368096000 +0000
++++ aten/src/ATen/test/CMakeLists.txt	2019-11-17 11:00:16.478435000 +0000
+@@ -27,7 +27,6 @@
+   ${CMAKE_CURRENT_SOURCE_DIR}/quantized_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/extension_backend_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/xla_tensor_test.cpp
+-  ${CMAKE_CURRENT_SOURCE_DIR}/tensor_iterator_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/cpu_generator_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/pow_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/reduce_ops_test.cpp)


### PR DESCRIPTION
Builds on #4, #6, and #7 

I've upstreamed `PyTorch-1.3.1-foss-2019b-Python-3.7.4.eb` and it builds across the board.

I've upstreamed `PyTorch-1.3.1-fosscuda-2019b-Python-3.7.4.eb` and it builds on a haswell P100 node and a POWER9 nodes.