### PR TITLE
Gurobi 9.0.0

### DIFF
--- a/easybuild/easyconfigs/g/Gurobi/Gurobi-9.0.0.eb
+++ b/easybuild/easyconfigs/g/Gurobi/Gurobi-9.0.0.eb
@@ -13,6 +13,7 @@ source_urls = ['https://packages.gurobi.com/%(version_major_minor)s/']
 sources = ['%(namelower)s%(version)s_linux64.tar.gz']
 checksums = ['07c48fe0f18097ddca6ddc6f5a276e1548a37b31016d0b8575bb12ec8f44546e']
 
+# If the environment variable GRB_LICENSE_FILE is already set then the following value will be ignored
 license_file = HOME + '/licenses/%(name)s/%(namelower)s.lic'
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/g/Gurobi/Gurobi-9.0.0.eb
+++ b/easybuild/easyconfigs/g/Gurobi/Gurobi-9.0.0.eb
@@ -1,0 +1,18 @@
+name = 'Gurobi'
+version = '9.0.0'
+
+homepage = 'https://www.gurobi.com'
+description = """The Gurobi Optimizer is a state-of-the-art solver for mathematical programming.
+ The solvers in the Gurobi Optimizer were designed from the ground up to exploit modern
+ architectures and multi-core processors, using the most advanced implementations of the
+ latest algorithms."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://packages.gurobi.com/%(version_major_minor)s/']
+sources = ['%(namelower)s%(version)s_linux64.tar.gz']
+checksums = ['07c48fe0f18097ddca6ddc6f5a276e1548a37b31016d0b8575bb12ec8f44546e']
+
+license_file = HOME + '/licenses/%(name)s/%(namelower)s.lic'
+
+moduleclass = 'math'


### PR DESCRIPTION
For INC976183

Pre-requisite: https://github.com/bear-rsg/easybuild-easyblocks/pull/8

Licence pre-requisites:
~https://gitlab.bham.ac.uk/res-comp-team/system-modules/merge_requests/20~ DONE!
~https://gitlab.bham.ac.uk/res-comp-team/bear-licences/merge_requests/5~ DONE

`Gurobi-9.0.0.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-sandybridge
* [ ] Ubuntu16 VM
* [ ] Created gitlab issues for testing and examples
