### PR TITLE
easyconf for PGI Community Edition 19.10

### DIFF
--- a/easybuild/easyconfigs/p/PGI/PGI-19.10-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-19.10-GCC-8.3.0-2.32.eb
@@ -1,9 +1,6 @@
 # Contribution from the Crick HPC team
 # uploaded by J. Sassmannshausen
 
-# Subprocess is used to check arch
-import subprocess as _subprocess
-
 name = 'PGI'
 version = '19.10'
 
@@ -13,15 +10,16 @@ description = "C, C++ and Fortran compilers from The Portland Group - PGI"
 toolchain = SYSTEM
 
 # N.B. recent file downloads from pgroup may require renaming from "...x86-64" to "...x86_64"
-sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-%(arch)s.tar.gz']
-
-# Assign the correct checksum for the architecture
-_arch = _subprocess.check_output(['uname', '-m']).strip()
-
-if _arch == 'ppc64le':
-    checksums = ['3b5f8d55c350d39b8ed252d94df4c0dff10c2a9c4b5ded522f495624576bc94b']
-else:
-    checksums = ['ac9db73ba80a66fe3bc875f63aaa9e16f54674a4e88b25416432430ba8cf203d']
+_base_filename = 'pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s'
+sources = ['%s-%%(arch)s.tar.gz' % _base_filename]
+checksums = [
+    {
+        '%s-ppc64le.tar.gz' % _base_filename:
+            '3b5f8d55c350d39b8ed252d94df4c0dff10c2a9c4b5ded522f495624576bc94b',
+        '%s-x86_64.tar.gz' % _base_filename:
+            'ac9db73ba80a66fe3bc875f63aaa9e16f54674a4e88b25416432430ba8cf203d',
+    }
+]
 
 local_gccver = '8.3.0'
 local_binutilsver = '2.32'

--- a/easybuild/easyconfigs/p/PGI/PGI-19.10-GCC-8.3.0-2.32.eb
+++ b/easybuild/easyconfigs/p/PGI/PGI-19.10-GCC-8.3.0-2.32.eb
@@ -1,0 +1,46 @@
+# Contribution from the Crick HPC team
+# uploaded by J. Sassmannshausen
+
+# Subprocess is used to check arch
+import subprocess as _subprocess
+
+name = 'PGI'
+version = '19.10'
+
+homepage = 'https://www.pgroup.com/'
+description = "C, C++ and Fortran compilers from The Portland Group - PGI"
+
+toolchain = SYSTEM
+
+# N.B. recent file downloads from pgroup may require renaming from "...x86-64" to "...x86_64"
+sources = ['pgilinux-20%(version_major)s-%(version_major)s%(version_minor)s-%(arch)s.tar.gz']
+
+# Assign the correct checksum for the architecture
+_arch = _subprocess.check_output(['uname', '-m']).strip()
+
+if _arch == 'ppc64le':
+    checksums = ['3b5f8d55c350d39b8ed252d94df4c0dff10c2a9c4b5ded522f495624576bc94b']
+else:
+    checksums = ['ac9db73ba80a66fe3bc875f63aaa9e16f54674a4e88b25416432430ba8cf203d']
+
+local_gccver = '8.3.0'
+local_binutilsver = '2.32'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
+
+dependencies = [
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
+    ('numactl', '2.0.12', '', ('GCCcore', local_gccver)),
+]
+
+install_amd = False
+install_java = False
+# Install OpenACC Unified Memory Evaluation package
+install_managed = True
+# Set 'install_nvidia' to True to ensure CUDA support is included
+install_nvidia = True
+
+# license file
+# license_file = HOME + '/licenses/pgi/license.dat'
+
+moduleclass = 'compiler'


### PR DESCRIPTION
For INC1003330

Requires https://github.com/bear-rsg/easybuild-easyblocks/pull/14

Related licence server gitlab MRs:
https://gitlab.bham.ac.uk/res-comp-team/system-modules/merge_requests/21
https://gitlab.bham.ac.uk/res-comp-team/bear-licences/merge_requests/6

Also requires removal of `PGROUPD_LICENSE_FILE` env var (see above), although this can be temporarily unset during install:
`unset PGROUPD_LICENSE_FILE && time eb PGI-19.10-GCC-8.3.0-2.32.eb -r -T`

* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-sandybridge
* [ ] EL7-power9
* [ ] Ubuntu16 VM