### PR TITLE
AutoDock 4.2.6

### DIFF
--- a/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.6-GCC-8.3.0.eb
+++ b/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.6-GCC-8.3.0.eb
@@ -9,7 +9,7 @@ description = """AutoDock is a suite of automated docking tools. It is designed 
  predict how small molecules, such as substrates or drug candidates, bind to
  a receptor of known 3D structure."""
 
-toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchain = {'name': 'GCC', 'version': '8.3.0'}
 
 source_urls = ['http://autodock.scripps.edu/downloads/previous-releases/autodock-4-2-5/tars/dist4251/']
 sources = ['%(namelower)ssuite-%(version)s-src.tar.gz']

--- a/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.6-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/a/AutoDock/AutoDock-4.2.6-GCCcore-8.3.0.eb
@@ -1,0 +1,25 @@
+# Currently there is not an EasyBlock to unify AutoDock and AutoGrid so this is a happy medium until then
+easyblock = 'ConfigureMake'
+
+name = 'AutoDock'
+version = '4.2.6'
+
+homepage = 'https://autodock.scripps.edu/'
+description = """AutoDock is a suite of automated docking tools. It is designed to
+ predict how small molecules, such as substrates or drug candidates, bind to
+ a receptor of known 3D structure."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['http://autodock.scripps.edu/downloads/previous-releases/autodock-4-2-5/tars/dist4251/']
+sources = ['%(namelower)ssuite-%(version)s-src.tar.gz']
+checksums = ['4b24ce4baf216a5e1a6a79bb664eeed684aed17cede64ff0061aa1bcc17874c4']
+
+start_dir = 'autodock'
+
+sanity_check_paths = {
+    'files': ["bin/autodock4"],
+    'dirs': []
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1005648

`AutoDock-4.2.6-GCC-8.3.0.eb` copied from `AutoDock-4.2.5.1-GCC-5.2.0.eb`
`AutoDock_Vina-1.1.2_linux_x86.eb` is "as is" in the repo

`AutoDock-4.2.6-GCC-8.3.0.eb AutoDock_Vina-1.1.2_linux_x86.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-sandybridge
* [ ] Ubuntu16 VM
