### PR TITLE
add missing extensions to IPython

### DIFF
--- a/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.9.0-foss-2019b-Python-3.7.4.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('Python', '3.7.4'),
     ('ZeroMQ', '4.3.2'),
     ('matplotlib', '3.1.1', versionsuffix),
+    ('PyYAML', '5.1.2'),  # required for jupyter_nbextensions_configurator
 ]
 
 use_pip = True
@@ -133,6 +134,12 @@ exts_list = [
     }),
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
+    }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
+    ('jupyter_nbextensions_configurator', '0.4.1', {
+        'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
     }),
     ('notebook', '6.0.2', {
         'checksums': ['399a4411e171170173344761e7fd4491a3625659881f76ce47c50231ed714d9b'],

--- a/easybuild/easyconfigs/i/IPython/IPython-7.9.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.9.0-fosscuda-2019b-Python-3.7.4.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('Python', '3.7.4'),
     ('ZeroMQ', '4.3.2'),
     ('matplotlib', '3.1.1', versionsuffix),
+    ('PyYAML', '5.1.2'),  # required for jupyter_nbextensions_configurator
 ]
 
 use_pip = True
@@ -133,6 +134,12 @@ exts_list = [
     }),
     ('ipywidgets', '7.5.1', {
         'checksums': ['e945f6e02854a74994c596d9db83444a1850c01648f1574adf144fbbabe05c97'],
+    }),
+    ('jupyter_contrib_core', '0.3.3', {
+        'checksums': ['e65bc0e932ff31801003cef160a4665f2812efe26a53801925a634735e9a5794'],
+    }),
+    ('jupyter_nbextensions_configurator', '0.4.1', {
+        'checksums': ['e5e86b5d9d898e1ffb30ebb08e4ad8696999f798fef3ff3262d7b999076e4e83'],
     }),
     ('notebook', '6.0.2', {
         'checksums': ['399a4411e171170173344761e7fd4491a3625659881f76ce47c50231ed714d9b'],


### PR DESCRIPTION
Based on upstream review of the fosscuda version, it seems that these extensions went missing at.

* [x] Assigned to reviewer

Rebuild: `IPython-7.9.0-foss-2019b-Python-3.7.4.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-sandybridge
* [ ] EL7-power9
* [ ] Ubuntu16 VM

Rebuild: `IPython-7.9.0-fosscuda-2019b-Python-3.7.4.eb`
* [ ] EL7-haswell
* [ ] EL7-power9
