### PR TITLE
Restoring the l/libaio/libaio-0.3.111-GCCcore-8.3.0.eb file that was …

### DIFF
--- a/easybuild/easyconfigs/l/libaio/libaio-0.3.111-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libaio/libaio-0.3.111-GCCcore-8.3.0.eb
@@ -1,0 +1,31 @@
+easyblock = 'MakeCp'
+
+name = 'libaio'
+version = '0.3.111'
+local_libversion = '1.0.1'
+
+homepage = 'https://pagure.io/libaio'
+description = "Asynchronous input/output library that uses the kernels native interface."
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://pagure.io/%(name)s/archive/%(name)s-%(version)s/']
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['0b0f9927743024fc83e1f37cbd5215a957ed43a0c25d6f863c5bfb5cc997592c']
+
+builddependencies = [('binutils', '2.32')]
+
+files_to_copy = [
+    (["src/libaio.a", "src/libaio.%s.%s" % (SHLIB_EXT, local_libversion)], "lib"),
+    (["src/libaio.h"], "include"),
+]
+
+postinstallcmds = ["cd %%(installdir)s/lib; ln -s libaio.%s.%s libaio.%s" % (SHLIB_EXT, local_libversion, SHLIB_EXT)]
+
+sanity_check_paths = {
+    'files': ['lib/libaio.a', 'lib/libaio.%s.%s' % (SHLIB_EXT, local_libversion), 'include/libaio.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
This file was introduced in https://github.com/bear-rsg/easybuild-easyconfigs/pull/102, but then accidentally removed again in https://github.com/bear-rsg/easybuild-easyconfigs/pull/103