### PR TITLE
Fixing OpenMC to work with new CMakeMake easyblock

### DIFF
--- a/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
@@ -33,7 +33,8 @@ dependencies = [
     ('uncertainties', '3.1.2'),
 ]
 
-postinstallcmds = ['pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .']
+postinstallcmds = ['cd %(builddir)s/%(namelower)s-%(version)s && ' \
+                   'pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .']
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/lib%%(namelower)s.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
@@ -33,8 +33,8 @@ dependencies = [
     ('uncertainties', '3.1.2'),
 ]
 
-postinstallcmds = [('cd %(builddir)s/%(namelower)s-%(version)s && '
-                    'pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .')]
+postinstallcmds = ['cd %(builddir)s/%(namelower)s-%(version)s && '
+                   'pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .']
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/lib%%(namelower)s.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/o/OpenMC/OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb
@@ -33,8 +33,8 @@ dependencies = [
     ('uncertainties', '3.1.2'),
 ]
 
-postinstallcmds = ['cd %(builddir)s/%(namelower)s-%(version)s && ' \
-                   'pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .']
+postinstallcmds = [('cd %(builddir)s/%(namelower)s-%(version)s && '
+                    'pip install --prefix=%(installdir)s --verbose --no-deps --ignore-installed --no-build-isolation .')]
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/lib%%(namelower)s.%s' % SHLIB_EXT],


### PR DESCRIPTION
Rebuild `OpenMC-0.11.0-foss-2019b-Python-3.7.4.eb`

* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-power9
* [ ] Ubuntu16 VM
