### PR TITLE
GTK+: Use the EasyBuild dev files not the ones from system packages

### DIFF
--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -39,7 +39,9 @@ default_component_specs = {
     'start_dir': '%(namelower)s-%(version)s',
 }
 
-prebuildopts = 'export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:${EBROOTPANGO}/share:${EBROOTATK}/share:${XDG_DATA_DIRS} && '
+prebuildopts = ('export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:'
+                '${EBROOTPANGO}/share:${EBROOTATK}/share:'
+                '${XDG_DATA_DIRS} && ')
 
 components = [
     ('hicolor-icon-theme', '0.17', {

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -39,7 +39,7 @@ default_component_specs = {
     'start_dir': '%(namelower)s-%(version)s',
 }
 
-prebuildopts = 'export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:${EBROOTPANGO}/share:${XDG_DATA_DIRS} && '
+prebuildopts = 'export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:${EBROOTPANGO}/share:${EBROOTATK}/share:${XDG_DATA_DIRS} && '
 
 components = [
     ('hicolor-icon-theme', '0.17', {

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -39,6 +39,8 @@ default_component_specs = {
     'start_dir': '%(namelower)s-%(version)s',
 }
 
+prebuildopts = 'export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:${EBROOTPANGO}/share:${XDG_DATA_DIRS} && '
+
 components = [
     ('hicolor-icon-theme', '0.17', {
         'source_urls': ['https://icon-theme.freedesktop.org/releases/'],


### PR DESCRIPTION
Fixes #138 for Ubuntu (where the relevant -dev system packages aren't installed)

`GTK+-3.24.13-GCCcore-8.3.0.eb`
* [x] Assigned to reviewer
* [ ] Ubuntu16 VM
