### PR TITLE
n2v TensorFlow changed to 1.15.0

### DIFF
--- a/easybuild/easyconfigs/n/n2v/n2v-0.1.11-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/n/n2v/n2v-0.1.11-foss-2019b-Python-3.7.4.eb
@@ -14,7 +14,7 @@ unpack_sources = False
 
 dependencies = [
     ('Python', '3.7.4'),
-    ('TensorFlow', '2.0.0', versionsuffix),
+    ('TensorFlow', '1.15.0', versionsuffix),
     ('matplotlib', '3.1.1', versionsuffix),
     ('Pillow', '6.2.1'),
     ('PyYAML', '5.1.2'),

--- a/easybuild/easyconfigs/n/n2v/n2v-0.1.11-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/n/n2v/n2v-0.1.11-fosscuda-2019b-Python-3.7.4.eb
@@ -14,7 +14,7 @@ unpack_sources = False
 
 dependencies = [
     ('Python', '3.7.4'),
-    ('TensorFlow', '2.0.0', versionsuffix),
+    ('TensorFlow', '1.15.0', versionsuffix),
     ('matplotlib', '3.1.1', versionsuffix),
     ('Pillow', '6.2.1'),
     ('PyYAML', '5.1.2'),
@@ -30,6 +30,8 @@ exts_default_options = {
 }
 
 exts_list = [
+    ('TensorFlow', '1.15.0', {
+    }),
     ('Keras', '2.2.5', {
         'checksums': ['0fb448b95643a708d25d2394183a2f3a84eefb55fb64917152a46826990113ea'],
     }),

--- a/easybuild/easyconfigs/n/n2v/n2v-0.1.11-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/n/n2v/n2v-0.1.11-fosscuda-2019b-Python-3.7.4.eb
@@ -30,8 +30,6 @@ exts_default_options = {
 }
 
 exts_list = [
-    ('TensorFlow', '1.15.0', {
-    }),
     ('Keras', '2.2.5', {
         'checksums': ['0fb448b95643a708d25d2394183a2f3a84eefb55fb64917152a46826990113ea'],
     }),

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -274,8 +274,8 @@ class EasyConfigTest(TestCase):
             'Boost.Python': ('1.64.0;', ['EMAN2-2.3-']),
             # scVelo's dependency numba requires LLVM 7x or 8x (see https://github.com/numba/llvmlite#compatibility)
             'LLVM': (r'[78]\.', ['numba-0.47.0-', 'scVelo-']),
-            # Deepbinner requires TensorFlow 1.15.0
-            'TensorFlow': ('1.15.0', ['Keras-2.3.1-', 'Deepbinner-c261ae9-', 'BEAR-Python-Sciences-2019b-']),
+            # Deepbinner and n2v require TensorFlow 1.15.0
+            'TensorFlow': ('1.15.0', ['Keras-2.3.1-', 'Deepbinner-c261ae9-', 'BEAR-Python-Sciences-2019b-', 'n2v-0.1.11-']),
             'Keras': ('2.3.1', ['Deepbinner-c261ae9-', 'BEAR-Python-Sciences-2019b-']),
             # ANSYSEM requires libpng 1.2.58
             'libpng': ('1.2.58', ['ANSYSEM-2020R1-', 'X11-20190717-', 'libdrm-2.4.99-', 'fontconfig-2.13.1-', 'Mesa-19.2.1-', 'freetype-2.10.1-']),


### PR DESCRIPTION
For INC1032175

* [x] Assigned to reviewer

n2v-0.1.11-foss-2019b-Python-3.7.4.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-power9
* [ ] Ubuntu16 VM

n2v-0.1.11-fosscuda-2019b-Python-3.7.4.eb
* [ ] EL7-haswell
* [ ] EL7-power9
