### PR TITLE
Tombo dependency mappy

### DIFF
--- a/easybuild/easyconfigs/m/mappy/mappy-2.17-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/mappy/mappy-2.17-foss-2019b-Python-3.7.4.eb
@@ -36,7 +36,7 @@ modextrapaths = {
 sanity_check_paths = {
     'files': [],
     'dirs': [
-        'lib/python%%(pyshortver)s/site-packages/%%(namelower)s-%%(version)s-py%%(pyshortver)s-linux-%s.egg' % _arch
+        'lib/python%(pyshortver)s/site-packages/%(namelower)s-%(version)s.dist-info'
     ],
 }
 


### PR DESCRIPTION
For INC1033734

Needed for #162 - updated sanity check path

easybuild/easyconfigs/m/mappy/mappy-2.17-foss-2019b-Python-3.7.4.eb
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
