### PR TITLE
Singlecellmethods with python igraph dep

### DIFF
--- a/easybuild/easyconfigs/g/GLPK/GLPK-4.65-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GLPK/GLPK-4.65-GCCcore-8.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'ConfigureMake'
+
+name = 'GLPK'
+version = '4.65'
+
+homepage = 'https://www.gnu.org/software/glpk/'
+description = """The GLPK (GNU Linear Programming Kit) package is intended for
+ solving large-scale linear programming (LP),
+ mixed integer programming (MIP), and other related problems.
+ It is a set of routines written in ANSI C 
+ and organized in the form of a callable library."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10']
+
+builddependencies = [('binutils', '2.32')]
+dependencies = [('GMP', '6.1.2')]
+
+configopts = "--with-gmp"
+
+sanity_check_paths = {
+    'files': ['bin/glpsol', 'include/glpk.h'] +
+             ['lib/libglpk.%s' % x for x in [SHLIB_EXT, 'a']],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/igraph/igraph-0.8.0-foss-2019b.eb
+++ b/easybuild/easyconfigs/i/igraph/igraph-0.8.0-foss-2019b.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'igraph'
+version = '0.8.0'
+
+homepage = 'https://igraph.org'
+description = """igraph is a collection of network analysis tools with the emphasis on 
+efficiency, portability and ease of use. igraph is open source and free. igraph can be 
+programmed in R, Python and C/C++."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/igraph/igraph/releases/download/%(version)s']
+sources = ['%(name)s-%(version)s.tar.gz']
+checksums = ['72637335600cf4758fd718009b16d92489b58a2f5dd96d884740d20cd5769649']
+
+builddependencies = [
+    ('Autotools', '20180311'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('GLPK', '4.65'),
+    ('libxml2', '2.9.9'),
+    ('zlib', '1.2.11'),
+]
+
+preconfigopts = "autoreconf -i && "
+# Remove hardcoded links to BLAS/LAPACK
+preconfigopts += "sed -i 's/-lblas/$LIBBLAS/' configure && "
+preconfigopts += "sed -i 's/-llapack/$LIBLAPACK/' configure && "
+
+configopts = "--with-external-blas --with-external-lapack --with-external-glpk"
+
+sanity_check_paths = {
+    'files': ['lib/libigraph.%s' % x for x in [SHLIB_EXT, 'la', 'a']] + ['lib/pkgconfig/igraph.pc'] +
+             ['include/igraph/igraph%s.h' % x for x in ['', '_blas', '_constants', '_lapack', '_types', '_version']],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.0-foss-2019b-Python-3.7.4.eb
@@ -11,14 +11,9 @@ description = """Implementation of the Leiden algorithm for various quality func
 
 toolchain = {'name': 'foss', 'version': '2019b'}
 
-builddependencies = [
-    ('Autoconf', '2.69'),
-    ('Automake', '1.16.1')
-]
-
 dependencies = [
     ('Python', '3.7.4'),
-    ('cairo', '1.16.0')
+    ('python-igraph', '0.8.0'),
 ]
 
 sanity_pip_check = True
@@ -29,17 +24,9 @@ exts_default_options = {
 }
 
 exts_list = [
-    ('pycairo', '1.19.1', {
-        'modulename': 'cairo',
-        'checksums': ['2c143183280feb67f5beb4e543fd49990c28e7df427301ede04fc550d3562e84'],
-    }),
-    ('texttable', '1.6.2', {
-        'checksums': ['eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4'],
-    }),
-    ('python-igraph', '0.8.2', {
-        'modulename': 'igraph',
-        'checksums': ['4601638d7d22eae7608cdf793efac75e6c039770ec4bd2cecf76378c84ce7d72'],
-    }),
+    #('texttable', '1.6.2', {
+    #    'checksums': ['eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4'],
+    #}),
     (name, version, {
         'checksums': ['ebab74ce92615b614bef9ec36a7318c45db928bd795ed262c4a10f4d009196ef'],
     }),

--- a/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/l/leidenalg/leidenalg-0.8.0-foss-2019b-Python-3.7.4.eb
@@ -24,11 +24,9 @@ exts_default_options = {
 }
 
 exts_list = [
-    #('texttable', '1.6.2', {
-    #    'checksums': ['eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4'],
-    #}),
     (name, version, {
         'checksums': ['ebab74ce92615b614bef9ec36a7318c45db928bd795ed262c4a10f4d009196ef'],
+        'installopts': '--install-option="--use-pkg-config"',  # use pkg-config to detect existing igraph
     }),
 ]
 

--- a/easybuild/easyconfigs/p/PyCairo/PyCairo-1.18.2-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/PyCairo/PyCairo-1.18.2-GCCcore-8.3.0.eb
@@ -1,0 +1,42 @@
+easyblock = 'PythonPackage'
+
+name = 'PyCairo'
+version = '1.18.2'
+
+homepage = 'https://pycairo.readthedocs.io/'
+description = """Python bindings for the cairo library"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531']
+
+multi_deps = {'Python': ['3.7.4', '2.7.16']}
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('cairo', '1.16.0'),
+]
+
+# PyGTK needs PyCairo installed by pip
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+# Don't build a wheel or the pkg-cfg file won't be installed
+installopts = '--no-binary=%(namelower)s'
+
+sanity_check_paths = {
+    'files': ['%s/%s.%s' % (p, n, e)
+              for (p, e) in [('include/pycairo', 'h'), ('lib/pkgconfig', 'pc')] for n in ['py3cairo', 'pycairo']],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/cairo'],
+}
+
+options = {'modulename': 'cairo'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/python-igraph/python-igraph-0.8.0-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/python-igraph/python-igraph-0.8.0-foss-2019b.eb
@@ -1,0 +1,47 @@
+easyblock = 'PythonBundle'
+
+name = 'python-igraph'
+version = '0.8.0'
+
+homepage = 'https://igraph.org/python'
+description = """Python interface to the igraph high performance graph library, primarily aimed at complex network
+ research and analysis."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+multi_deps = {'Python': ['3.7.4', '2.7.16']}
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('igraph', '0.8.0'),
+    ('PyCairo', '1.18.2'),
+]
+
+use_pip = False
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('texttable', '1.6.2', {
+        'checksums': ['eff3703781fbc7750125f50e10f001195174f13825a92a45e9403037d539b4f4'],
+    }),
+    (name, version, {
+        'checksums': ['47e6bb48ec7dbfddbd89cf064a24b271783a1490fc688ebce17fbd652bcdab8e'],
+        'buildopts': '--use-pkg-config',
+        'installopts': '--use-pkg-config',
+        'modulename': 'igraph',
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/igraph'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+# cairo must be available for proper plotting support
+sanity_check_commands = ["python -c 'from igraph.drawing.utils import find_cairo; cairo = find_cairo(); cairo.Context'"]
+
+moduleclass = 'lib'


### PR DESCRIPTION
For INC1032987

`time eb leidenalg-0.8.0-foss-2019b-Python-3.7.4.eb -fTr && time eb  singlecellmethods-6f3a00d-foss-2019b-R-3.6.2.eb -fTr`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-power9
* [ ] Ubuntu16 VM

Fixes https://github.com/bear-rsg/easybuild-easyconfigs/pull/165

NOTE: These packages are all straight from upstream:

- GLPK-4.65-GCCcore-8.3.0.eb
- igraph-0.8.0-foss-2019b.eb
- PyCairo-1.18.2-GCCcore-8.3.0.eb
- python-igraph-0.8.0-foss-2019b.eb
