### PR TITLE
remove Deepbinner, so Sciences and DataScience can be used together

### DIFF
--- a/easybuild/easyconfigs/b/BEAR-Python-Sciences/BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BEAR-Python-Sciences/BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb
@@ -24,7 +24,6 @@ dependencies = [
     ('astropy', '4.0', versionsuffix),
     ('CGAL', '4.14.1', versionsuffix),
     ('CNVnator', '0.4.1', versionsuffix),
-    ('Deepbinner', 'c261ae9', versionsuffix),
     ('HDDM', '0.7.6', versionsuffix),
     ('MedPy', '0.4.0', versionsuffix),
     ('NiBabel', '3.1.0', versionsuffix),


### PR DESCRIPTION
For Portal

Rebuild: `BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
