### PR TITLE
only on pull requests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,5 @@
 name: easyconfigs unit tests
-on: [push]
+on: [pull_request]
 jobs:
   test-suite:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This is the wrong way round. More tests are done on PRs than on a push, so that is what we want to trigger the test.

You can see an example where this impact with fgeo in 2019b:
* push: https://github.com/bear-rsg/easybuild-easyconfigs/actions/runs/112554334
* pull request: https://github.com/bear-rsg/easybuild-easyconfigs/actions/runs/112555116