### PR TITLE
Bumped version of fineSTRUCTURE, with now fewer dependencies

### DIFF
--- a/easybuild/easyconfigs/f/fineSTRUCTURE/fineSTRUCTURE-4.1.1-foss-2019b.eb
+++ b/easybuild/easyconfigs/f/fineSTRUCTURE/fineSTRUCTURE-4.1.1-foss-2019b.eb
@@ -1,0 +1,25 @@
+easyblock = 'Tarball'
+
+name = 'fineSTRUCTURE'
+version = '4.1.1'
+
+homepage = 'https://people.maths.bris.ac.uk/~madjl/finestructure/finestructure_info.html'
+description = """fineSTRUCTURE is a fast and powerful algorithm for identifying population structure using
+ dense sequencing data."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://people.maths.bris.ac.uk/~madjl/finestructure/']
+sources = ['fs_%(version)s.zip']
+checksums = ['7af2dd51b02bf117e364f70e76d03920b0cd9ec17111b5be94dd2a5ab906b75e']
+
+postinstallcmds = ["cd %(installdir)s && mkdir bin && cp fs_linux* bin/fs"]
+
+modextrapaths = {'PATH': 'bin'}
+
+sanity_check_paths = {
+    'files': ['bin/fs'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1034383

The previous fineSTRUCTURE had a GSL dependency, but needed an older library version. This one doesn't need GSL at all.

`fineSTRUCTURE-4.1.1-foss-2019b.eb`
* [ ] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
~~* [ ] EL7-power9~~
* [ ] Ubuntu16 VM
