### PR TITLE
use rstudio 1.2 version for now

### DIFF
--- a/easybuild/easyconfigs/r/rstudio/rstudio-1.2.5042-foss-2020a-Java-11-R-4.0.0.eb
+++ b/easybuild/easyconfigs/r/rstudio/rstudio-1.2.5042-foss-2020a-Java-11-R-4.0.0.eb
@@ -1,0 +1,58 @@
+easyblock = 'CMakeMake'
+
+name = 'rstudio'
+version = '1.2.5042'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = 'https://www.rstudio.com/'
+description = """This RStudio Server version.
+RStudio is a set of integrated tools designed to help you be more productive with R.
+
+The server can be started with:
+  rserver --server-daemonize=0 --www-port 8787 --rsession-which-r=$(which R)
+"""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+source_urls = ['https://github.com/rstudio/rstudio/archive']
+sources = ['v%(version)s.tar.gz']
+patches = [
+    'rstudio-1.2.5033_fix_boost_170_compat.patch',
+    'rstudio-1.2.5033_update_gwt.patch',
+    '%(name)s-server-1.3.959-fix-rslave.patch',
+]
+checksums = [
+    '2bcd1d525d92e9ce42f4c7a57383c025e10d34313f8ed245429f02980b47c1fc',  # v1.2.5042.tar.gz
+    'd252111e28a7de8602b4df1f66b36dded260061f094b504895e5c789f8681091',  # rstudio-1.2.5033_fix_boost_170_compat.patch
+    'e0b4e165e45357bfaaefbd6f20a7ee69701c56bd623fa2bdfe6df4a1cabc4415',  # rstudio-1.2.5033_update_gwt.patch
+    'e6ab9c3df3035e502fa855c33cfb6085b11bf65094de469257a76ceb2b5b329a',  # rstudio-server-1.3.959-fix-rslave.patch
+]
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+    ('CMake', '3.16.4'),
+    ('ant', '1.10.8', '-Java-%(javaver)s', True),
+]
+
+dependencies = [
+    ('Boost', '1.72.0'),
+    ('R', '4.0.0'),
+    ('Java', '11', '', True),
+]
+
+osdependencies = [
+    ('pam-devel', 'libpam0g-dev')
+]
+
+build_type = "Release"
+local_dep_dir = "%(builddir)s/%(name)s-%(version)s/dependencies/common"
+preconfigopts = ("(cd %s && ./install-dictionaries && "
+                 "./install-pandoc && ./install-mathjax && ./install-gwt) && ") % local_dep_dir
+configopts = "-DRSTUDIO_TARGET=Server -DRSTUDIO_BOOST_SIGNALS_VERSION=2"
+
+sanity_check_paths = {
+    'files': ["bin/rstudio-server"],
+    'dirs': ['bin', 'extras', 'resources', 'www', 'www-symbolmaps', 'R'],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/r/rstudio/rstudio-1.2.5042-foss-2020a-Java-11-R-4.0.0.eb
+++ b/easybuild/easyconfigs/r/rstudio/rstudio-1.2.5042-foss-2020a-Java-11-R-4.0.0.eb
@@ -2,15 +2,11 @@ easyblock = 'CMakeMake'
 
 name = 'rstudio'
 version = '1.2.5042'
-versionsuffix = '-Java-%(javaver)s'
+versionsuffix = '-Java-%(javaver)s-R-%(rver)s'
 
 homepage = 'https://www.rstudio.com/'
 description = """This RStudio Server version.
-RStudio is a set of integrated tools designed to help you be more productive with R.
-
-The server can be started with:
-  rserver --server-daemonize=0 --www-port 8787 --rsession-which-r=$(which R)
-"""
+RStudio is a set of integrated tools designed to help you be more productive with R."""
 
 toolchain = {'name': 'foss', 'version': '2020a'}
 


### PR DESCRIPTION
For the Portal - while we debug what has changed in RStudio Server 1.3 that is stopping our connections from working in the Portal.

`rstudio-1.2.5042-foss-2020a-Java-11-R-4.0.0.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
