### PR TITLE
Various bioinformatics packages

### DIFF
--- a/easybuild/easyconfigs/b/Bismark/Bismark-0.22.3-foss-2019b.eb
+++ b/easybuild/easyconfigs/b/Bismark/Bismark-0.22.3-foss-2019b.eb
@@ -1,0 +1,37 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2013-2014 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+easyblock = 'Tarball'
+
+name = 'Bismark'
+version = '0.22.3'
+
+homepage = 'https://www.bioinformatics.babraham.ac.uk/projects/bismark/'
+description = "A tool to map bisulfite converted sequence reads and determine cytosine methylation states"
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://github.com/FelixKrueger/Bismark/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['704523b5cd23a2976ef72484ce3df66208d09220eb71bf9e074446fc881b2e11']
+
+dependencies = [
+    ('Perl', '5.30.0'),
+    ('Bowtie2', '2.3.5.1'),
+    ('SAMtools', '1.10'),
+]
+
+sanity_check_paths = {
+    'files': ['bismark', 'bismark2bedGraph', 'bismark2report', 'bismark_genome_preparation',
+              'bismark_methylation_extractor', 'coverage2cytosine', 'deduplicate_bismark'],
+    'dirs': [],
+}
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/cutadapt/cutadapt-2.7-GCCcore-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/c/cutadapt/cutadapt-2.7-GCCcore-8.3.0-Python-3.7.4.eb
@@ -1,0 +1,53 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics (SIB)
+# Biozentrum - University of Basel
+# Modified by: Adam Huffman, Jonas Demeulemeester
+# The Francis Crick Institute
+# Modufied by: Albert Bogdanowicz
+# Institute of Biochemistry and Biophysics PAS
+
+easyblock = 'PythonBundle'
+
+name = 'cutadapt'
+version = '2.7'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://opensource.scilifelab.se/projects/cutadapt/'
+description = """Cutadapt finds and removes adapter sequences, primers, poly-A tails and
+ other types of unwanted sequence from your high-throughput sequencing reads."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [('Python', '3.7.4')]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('xopen', '0.8.4', {
+        'checksums': ['dcd8f5ef5da5564f514a990573a48a0c347ee1fdbb9b6374d31592819868f7ba'],
+    }),
+    ('dnaio', '0.4.1', {
+        'checksums': ['371a461bac0e821ff52f6235f0de4533ac73b0e990b470e9625486f2e6df2cd7'],
+    }),
+    (name, version, {
+        'checksums': ['070dec8d94b8bda72906c614b9e71bd61254a67a176dd17e5b57671edd567983'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/cutadapt'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "cutadapt --help",
+    "python -c 'import cutadapt.utils'",  # requires xopen
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/pigz/pigz-2.4-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/p/pigz/pigz-2.4-GCCcore-8.3.0.eb
@@ -1,0 +1,55 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics
+# Biozentrum - University of Basel
+#
+# 2.4.0:
+# Jonas Demeulemeester
+# The Francis Crick Institute
+##
+easyblock = 'MakeCp'
+
+name = 'pigz'
+version = '2.4'
+
+homepage = 'https://zlib.net/pigz/'
+
+description = """
+ pigz, which stands for parallel implementation of gzip, is a fully
+ functional replacement for gzip that exploits multiple processors and multiple
+ cores to the hilt when compressing data. pigz was written by Mark Adler, and
+ uses the zlib and pthread libraries.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [
+    'https://zlib.net/pigz/',
+    'https://zlib.net/pigz/fossils/',
+]
+sources = [SOURCE_TAR_GZ]
+patches = ['%(name)s-%(version)s_makefile.patch']
+checksums = [
+    'a4f816222a7b4269bd232680590b579ccc72591f1bb5adafcd7208ca77e14f73',  # pigz-2.4.tar.gz
+    '8de19216a69b6402942f73177c566791f0c7fa4649376029d30d0c537d2195c1',  # pigz-2.4_makefile.patch
+]
+
+builddependencies = [
+    ('binutils', '2.32'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+]
+
+buildopts = 'CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="-L$EBROOTZLIB/lib"'
+
+files_to_copy = [(["pigz", "unpigz"], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/pigz', 'bin/unpigz'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/t/Trim_Galore/Trim_Galore-0.6.5-GCCcore-8.3.0-Java-11-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/Trim_Galore/Trim_Galore-0.6.5-GCCcore-8.3.0-Java-11-Python-3.7.4.eb
@@ -1,0 +1,53 @@
+# Contribution from the Crick HPC team
+# uploaded by J. Sassmannshausen
+#
+# Updated to version 0.6.2: Pavel Grochal (INUITS)
+# Updated to version 0.6.5: Alex Domingo (VUB)
+#
+
+easyblock = 'Tarball'
+
+name = 'Trim_Galore'
+version = '0.6.5'
+versionsuffix = '-Java-%(javaver)s-Python-%(pyver)s'
+
+
+homepage = 'https://www.bioinformatics.babraham.ac.uk/projects/trim_galore/'
+description = """Trim Galore is a wrapper around Cutadapt and FastQC to
+consistently apply adapter and quality trimming to FastQ files, with extra
+functionality for RRBS data."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/FelixKrueger/TrimGalore/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['3e92c2f5b6147a30f774a5bea4b344aebb014d6dd9b3e9b55a72046b04485783']
+
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('Java', '11', '', True),
+    ('pigz', '2.4'),
+    ('Perl', '5.30.0'),
+    ('FastQC', '0.11.9', '-Java-%(javaver)s', True),
+    ('cutadapt', '2.7', '-Python-%(pyver)s'),
+]
+
+postinstallcmds = [
+    "chmod +x %(installdir)s/%(namelower)s",
+    "sed -i '1 i#!/usr/bin/env perl' %(installdir)s/%(namelower)s",
+]
+
+modextrapaths = {'PATH': ''}
+
+sanity_check_paths = {
+    'files': ["trim_galore"],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    "trim_galore --help"
+]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1040529 and INC1040531

Bismark is an update of existing EC. Trim_Galore, and the cutapdt and pigz deps, are all directly from upstream.

* [x] Assigned to reviewer

`Bismark-0.22.3-foss-2019b.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM

`Trim_Galore-0.6.5-GCCcore-8.3.0-Java-11-Python-3.7.4.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM