### PR TITLE
Bracken updated

### DIFF
--- a/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
@@ -1,5 +1,5 @@
 # This easyconfig was created by the BEAR Software team at the University of Birmingham.
-easyblock = 'ConfigureMake'
+easyblock = 'MakeCp'
 
 name = 'Bracken'
 version = '2.6.0'
@@ -20,8 +20,10 @@ dependencies = [
     ('Python', '3.7.4'),
 ]
 
-skipsteps = ['configure', 'install']
+skipsteps = ['configure']
 build_cmd = 'cd src && make'
+
+files_to_copy = ['bracken', 'bracken-build', 'analysis_scripts', 'sample_data', 'src']
 
 sanity_check_paths = {
     'files': ['bracken', 'bracken-build'],

--- a/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
@@ -1,5 +1,5 @@
 # This easyconfig was created by the BEAR Software team at the University of Birmingham.
-easyblock = 'Tarball'
+easyblock = 'ConfigureMake'
 
 name = 'Bracken'
 version = '2.6.0'
@@ -20,6 +20,7 @@ dependencies = [
     ('Python', '3.7.4'),
 ]
 
+skipsteps = ['configure', 'install']
 build_cmd = 'cd src && make'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/Bracken/Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
@@ -1,5 +1,5 @@
 # This easyconfig was created by the BEAR Software team at the University of Birmingham.
-easyblock = 'MakeCp'
+easyblock = 'Tarball'
 
 name = 'Bracken'
 version = '2.6.0'
@@ -20,18 +20,15 @@ dependencies = [
     ('Python', '3.7.4'),
 ]
 
-skipsteps = ['configure']
 build_cmd = 'cd src && make'
 
 sanity_check_paths = {
-    'files': ['bin/bracken', 'bin/bracken-build'],
-    'dirs': ['analysis_scripts', 'sample_data', 'src'],
+    'files': ['bracken', 'bracken-build'],
+    'dirs': ['analysis_scripts', 'sample_data', 'src']
 }
 
-files_to_copy = [(['bracken', 'bracken-build'], 'bin'), 'analysis_scripts', 'sample_data', 'src']
-
 modextrapaths = {
-    'PATH': 'src'
+    'PATH': ['', 'src']
 }
 
 moduleclass = 'bio'


### PR DESCRIPTION
For INC1042056

Update for #209 

Incident reopened by user. Error when running bracken: "python: can't open file '/rds/bear-apps/2019b/EL7-haswell/software/Bracken/2.6.0-foss-2019b-Python-3.7.4/bin/src/est_abundance.py': [Errno 2] No such file or directory".

I assume this is due to using 'files_to_copy' and copying the binaries to 'bin' in the easyconfig, so I have removed it.

Bracken-2.6.0-foss-2019b-Python-3.7.4.eb
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM