### PR TITLE
gwpv

### DIFF
--- a/easybuild/easyconfigs/g/gwpv/gwpv-0.1.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/gwpv/gwpv-0.1.0-foss-2020a-Python-3.8.2.eb
@@ -1,0 +1,50 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'gwpv'
+version = '0.1.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://github.com/nilsleiffischer/gwpv"
+description = """Visualize gravitational wave data with ParaView"""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('ParaView', '5.8.0', '%s-mpi' % versionsuffix),
+    ('SciPy-bundle', '2020.03', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
+    ('numba', '0.50.0', versionsuffix),
+    ('PyYAML', '5.3') ,
+    ('tqdm', '4.47.0'),
+    ('GSL', '2.6'),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('numpy-quaternion', '2020.5.19.15.27.24', {
+        'modulename': 'quaternion',
+        'checksums': ['7102931862e13d2266b9255bef215becdedda1ad88d36390f974a58ad7d38b19'],
+    }),
+    ('spinsfast', '104.2019.3.20.13.47.8', {
+        'preinstallopts': "export FFTW3_HOME=$EBROOTFFTW && ",
+        'checksums': ['bc92536cb0318b5f69eb1c9bca3e800f9d070909a75e3caf2fd199f0054c3ba2'],
+    }),
+    ('spherical-functions', '2020.6.5.10.11.45', {
+        'checksums': ['88344c04e1d0fedbe6eba8e28a0c2613702ee1686abc4b91b004c5118bbccc44'],
+    }),
+    (name, version, {
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/nilsleiffischer/gwpv/archive/'],
+        'checksums': ['1c67ad72d4118ef06cda2b6e23496cafb2b8287f53c33db1efb6658f57b79207'],
+    }),
+]
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/g/gwpv/gwpv-0.1.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/g/gwpv/gwpv-0.1.0-foss-2020a-Python-3.8.2.eb
@@ -16,7 +16,7 @@ dependencies = [
     ('SciPy-bundle', '2020.03', versionsuffix),
     ('h5py', '2.10.0', versionsuffix),
     ('numba', '0.50.0', versionsuffix),
-    ('PyYAML', '5.3') ,
+    ('PyYAML', '5.3'),
     ('tqdm', '4.47.0'),
     ('GSL', '2.6'),
 ]

--- a/easybuild/easyconfigs/n/numba/numba-0.50.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/n/numba/numba-0.50.0-foss-2020a-Python-3.8.2.eb
@@ -1,0 +1,53 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+
+easyblock = 'PythonBundle'
+
+name = 'numba'
+version = '0.50.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://numba.pydata.org/'
+description = """Numba is an Open Source NumPy-aware optimizing compiler for
+Python sponsored by Continuum Analytics, Inc. It uses the remarkable LLVM
+compiler infrastructure to compile Python syntax to machine code."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('SciPy-bundle', '2020.03', versionsuffix),
+    ('LLVM', '9.0.1'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('llvmlite', '0.33.0', {
+        'patches': ['llvmlite-0.31.0_fix-ffi-Makefile.patch'],
+        'preinstallopts': "export LLVM_CONFIG=${EBROOTLLVM}/bin/llvm-config && ",
+        'checksums': [
+            # llvmlite-0.31.0.tar.gz
+            '9c8aae96f7fba10d9ac864b443d1e8c7ee4765c31569a2b201b3d0b67d8fc596',
+            # llvmlite-0.31.0_fix-ffi-Makefile.patch
+            '672aba7b753dcfe5cb07c731bf1ec8bde1de148d4e0e2d10f6be81fb17f34bbc',
+        ],
+    }),
+    (name, version, {
+        'checksums': ['c9e5752821530694294db41ee19a4b00e5826c689821907f6c2ece9a02756b29'],
+    }),
+]
+
+fix_python_shebang_for = ['bin/*']
+
+sanity_check_paths = {
+    'files': ['bin/numba', 'bin/pycc'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = ["numba --help"]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
@@ -1,0 +1,52 @@
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.8.0'
+versionsuffix = '-Python-%(pyver)s-mpi'
+
+homepage = "https://www.paraview.org"
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+local_download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['https://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
+sources = ["ParaView-v%(version)s.tar.xz"]
+checksums = ['219e4107abf40317ce054408e9c3b22fb935d464238c1c00c0161f1c8697a3f9']
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('SciPy-bundle', '2020.03', '-Python-3.8.2'),
+    ('XZ', '5.2.5'),
+    ('HDF5', '1.10.6'),
+    ('netCDF', '4.7.4'),
+    ('libGLU', '9.0.1'),
+    ('X11', '20200222'),
+    ('Mesa', '20.0.2'),
+    ('Qt5', '5.14.1'),
+    ('zlib', '1.2.11'),
+    ('FFmpeg', '4.2.2'),
+    ('Szip', '2.1.1'),
+]
+
+builddependencies = [('CMake', '3.16.4')]
+
+separate_build_dir = True
+
+# Paraview
+configopts = '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON -DBUILD_SHARED_LIBS=ON '
+configopts += '-DPARAVIEW_USE_MPI=ON '
+configopts += '-DPARAVIEW_ENABLE_FFMPEG=ON '
+
+# OpenGL & Mesa
+configopts += '-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s ' % SHLIB_EXT
+configopts += '-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include'
+configopts += '-DVTK_OPENGL_HAS_OSMESA=ON '
+
+sanity_check_paths = {
+    'files': ['bin/paraview'],
+    'dirs': ['include/paraview-%(version_major_minor)s', 'lib'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
@@ -53,6 +53,6 @@ sanity_check_paths = {
     'dirs': ['include/paraview-%(version_major_minor)s', 'lib/python%(pyshortver)s/site-packages'],
 }
 
-modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+modextrapaths = {'PYTHONPATH': ['lib64/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-foss-2020a-Python-3.8.2-mpi.eb
@@ -35,9 +35,13 @@ builddependencies = [('CMake', '3.16.4')]
 separate_build_dir = True
 
 # Paraview
-configopts = '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON -DBUILD_SHARED_LIBS=ON '
+configopts = '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON -DPARAVIEW_BUILD_SHARED_LIBS=ON '
 configopts += '-DPARAVIEW_USE_MPI=ON '
 configopts += '-DPARAVIEW_ENABLE_FFMPEG=ON '
+
+# Python
+configopts += '-DPARAVIEW_USE_PYTHON=ON '
+configopts += '-DPython3_ROOT_DIR=$EBROOTPYTHON '
 
 # OpenGL & Mesa
 configopts += '-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s ' % SHLIB_EXT
@@ -45,8 +49,10 @@ configopts += '-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include'
 configopts += '-DVTK_OPENGL_HAS_OSMESA=ON '
 
 sanity_check_paths = {
-    'files': ['bin/paraview'],
-    'dirs': ['include/paraview-%(version_major_minor)s', 'lib'],
+    'files': ['bin/paraview', 'bin/pvpython'],
+    'dirs': ['include/paraview-%(version_major_minor)s', 'lib/python%(pyshortver)s/site-packages'],
 }
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
 
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
@@ -1,0 +1,22 @@
+easyblock = 'PythonPackage'
+
+name = 'tqdm'
+version = '4.47.0'
+
+homepage = "https://github.com/tqdm/tqdm"
+description = """A fast, extensible progress bar for Python and CLI"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [('binutils', '2.34')]
+
+multi_deps = {'Python': ['2.7.18', '3.8.2']}
+
+sanity_pip_check = True
+use_pip = True
+download_dep_fail = True
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/t/tqdm/tqdm-4.47.0-GCCcore-9.3.0.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
+checksums = ['63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7']
 
 builddependencies = [('binutils', '2.34')]
 


### PR DESCRIPTION
For INC1044341

Created in 2020a due to the dependencies lining up here for only having one version of LLVM in the dependencies.

numba is from upstream; ParaView is from upstream, but with changes I am pushing back; and tqdm is an update from the 2019b version.

`gwpv-0.1.0-foss-2020a-Python-3.8.2.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
