### PR TITLE
TensorFlow 2.2, and deps, from upstream

### DIFF
--- a/easybuild/easyconfigs/b/Bazel/Bazel-2.0.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-2.0.0-GCCcore-8.3.0.eb
@@ -1,0 +1,25 @@
+name = 'Bazel'
+version = '2.0.0'
+
+homepage = 'https://bazel.io/'
+description = """Bazel is a build tool that builds code quickly and reliably.
+It is used to build the majority of Google's software."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/bazelbuild/bazel/releases/download/%(version)s']
+sources = ['%(namelower)s-%(version)s-dist.zip']
+patches = ['Bazel-0.29.1_fix-gold-flag.patch']
+checksums = [
+    '724da3c656f68e787a86ebb9844773aa1c2e3a873cc39462a8f1b336153d6cbb',  # bazel-2.0.0-dist.zip
+    '99928d0902beeaf962a8ad14db8432f8e5114645e3caf64c7ee2fa136c31609f',  # Bazel-0.29.1_fix-gold-flag.patch
+]
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('Python', '3.7.4'),
+    ('Zip', '3.0'),
+]
+dependencies = [('Java', '11', '', True)]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/pybind11/pybind11-2.4.3-GCCcore-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/p/pybind11/pybind11-2.4.3-GCCcore-8.3.0-Python-3.7.4.eb
@@ -1,0 +1,29 @@
+easyblock = 'CMakeMake'
+
+name = 'pybind11'
+version = '2.4.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://pybind11.readthedocs.io'
+description = """pybind11 is a lightweight header-only library that exposes C++ types in Python and vice versa,
+ mainly to create Python bindings of existing C++ code."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/pybind/pybind11/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['1eed57bc6863190e35637290f97a20c81cfe4d9090ac0a24f3bbf08f265eb71d']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+    ('Eigen', '3.3.7', '', True),
+]
+dependencies = [('Python', '3.7.4')]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['include/pybind11', 'share/cmake/pybind11'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-cuda-build.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.1.0_fix-cuda-build.patch
@@ -1,0 +1,47 @@
+fix for "undeclared inclusion(s) in rule" errors when building TensorFlow 1.14.0 with CUDA support,
+if the installation directory for GCC is hosted in a path that is a symlink to another path;
+the symlinked path is resolved in several places (both by 'gcc' itself and by the TF build process),
+which makes hard comparisons between paths fail
+author: Alexander Grund based on original patch by Kenneth Hoste (HPC-UGent)
+diff --git a/third_party/gpus/cuda_configure.bzl b/third_party/gpus/cuda_configure.bzl
+index ba4bd8ad75..dab492ecda 100644
+--- a/third_party/gpus/cuda_configure.bzl
++++ b/third_party/gpus/cuda_configure.bzl
+@@ -303,11 +303,36 @@ def _get_cxx_inc_directories_impl(repository_ctx, cc, lang_is_cpp):
+     else:
+         inc_dirs = result.stderr[index1 + 1:index2].strip()
+
+-    return [
++    compiler_includes = [
+         _normalize_include_path(repository_ctx, _cxx_inc_convert(p))
+         for p in inc_dirs.split("\n")
+     ]
+
++    # fix include path by also including paths where resolved symlink is replaced by original path
++    # Try to find real path to CC installation to "see through" compiler wrappers
++    # GCC has the path to g++
++    index1 = result.stderr.find("COLLECT_GCC=")
++    if index1 != -1:
++      index1 = result.stderr.find("=", index1)
++      index2 = result.stderr.find("\n", index1)
++      cc_topdir = repository_ctx.path(result.stderr[index1 + 1 : index2]).dirname.dirname
++    else:
++      # Clang has the directory
++      index1 = result.stderr.find("InstalledDir: ")
++      if index1 != -1:
++        index1 = result.stderr.find(" ", index1)
++        index2 = result.stderr.find("\n", index1)
++        cc_topdir = repository_ctx.path(result.stderr[index1 + 1 : index2]).dirname
++      else:
++        # Fallback to the CC path
++        cc_topdir = repository_ctx.path(cc).dirname.dirname
++    cc_topdir_resolved = str(cc_topdir.realpath).strip()
++    cc_topdir = str(cc_topdir).strip()
++    if cc_topdir_resolved != cc_topdir:
++        original_compiler_includes = [p.replace(cc_topdir_resolved, cc_topdir) for p in compiler_includes]
++        compiler_includes = compiler_includes + original_compiler_includes
++    return compiler_includes
++
+ def get_cxx_inc_directories(repository_ctx, cc, tf_sysroot):
+     """Compute the list of default C and C++ include directories."""
+

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,142 @@
+easyblock = 'PythonBundle'
+
+name = 'TensorFlow'
+version = '2.2.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+builddependencies = [
+    ('Bazel', '2.0.0'),
+    # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
+    ('git', '2.23.0', '-nodocs'),
+    # For SciPy
+    ('pybind11', '2.4.3', versionsuffix),
+]
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
+use_pip = True
+
+exts_list = [
+    ('scipy', '1.4.1', {
+        'patches': ['scipy-1.4.1-fix-pthread.patch'],
+        'checksums': [
+            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
+            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
+        ],
+    }),
+    ('Markdown', '3.2.1', {
+        'checksums': ['90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902'],
+    }),
+    ('pyasn1-modules', '0.2.8', {
+        'modulename': 'pyasn1_modules',
+        'checksums': ['905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e'],
+    }),
+    ('rsa', '4.0', {
+        'checksums': ['1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487'],
+    }),
+    ('cachetools', '4.1.0', {
+        'checksums': ['1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab'],
+    }),
+    ('google-auth', '1.14.2', {
+        'modulename': 'google.auth',
+        'checksums': ['2243db98475f7f2033c41af5185333cbf13780e8f5f96eaadd997c6f34181dcc'],
+    }),
+    ('oauthlib', '3.1.0', {
+        'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
+    }),
+    ('requests-oauthlib', '1.3.0', {
+        'modulename': 'requests_oauthlib',
+        'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
+    }),
+    ('google-auth-oauthlib', '0.4.1', {
+        'modulename': 'google_auth_oauthlib',
+        'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
+    }),
+    ('Werkzeug', '1.0.1', {
+        'checksums': ['6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c'],
+    }),
+    ('protobuf', '3.11.3', {
+        'modulename': 'google.protobuf',
+        'checksums': ['c77c974d1dadf246d789f6dad1c24426137c9091e930dbf50e0a29c1fcf00b1f'],
+    }),
+    ('absl-py', '0.9.0', {
+        'modulename': 'absl',
+        'checksums': ['75e737d6ce7723d9ff9b7aa1ba3233c34be62ef18d5859e706b8fdc828989830'],
+    }),
+    ('astunparse', '1.6.3', {
+        'checksums': ['5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872'],
+    }),
+    ('grpcio', '1.28.1', {
+        'modulename': 'grpc',
+        'checksums': ['cbc322c5d5615e67c2a15be631f64e6c2bab8c12505bc7c150948abdaa0bdbac'],
+    }),
+    ('tensorboard-plugin-wit', '1.6.0.post3', {
+        'source_tmpl': 'tensorboard_plugin_wit-%(version)s-py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['1fdf4ac343f1665453205aef8bb227b0204893bb5ffb792d2ed4509b1daf3d4f'],
+    }),
+    ('tensorboard', '2.2.1', {
+        'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['9a2a2dc9856187679e93f3c95e5dc771dd47e3257db09767b4be118d734b4dc2'],
+    }),
+    ('google-pasta', '0.2.0', {
+        'modulename': 'pasta',
+        'checksums': ['c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e'],
+    }),
+    ('termcolor', '1.1.0', {
+        'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
+    }),
+    ('tensorflow-estimator', version, {
+        'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['d09dacdd127f2579cea8d5af21f4a918036b8ae246adc82f26b61f91cc247dc2'],
+    }),
+    ('gast', '0.3.3', {
+        'checksums': ['b881ef288a49aa81440d2c5eb8aeefd4c2bb8993d5f50edae7413a85bfdb3b57'],
+    }),
+    ('opt-einsum', '3.2.1', {
+        'source_tmpl': 'opt_einsum-%(version)s.tar.gz',
+        'checksums': ['83b76a98d18ae6a5cc7a0d88955a7f74881f0e567a0f4c949d24c942753eb998'],
+    }),
+    ('wrapt', '1.12.1', {
+        'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
+    }),
+    ('Keras-Preprocessing', '1.1.0', {
+        'modulename': 'keras_preprocessing',
+        'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
+        'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
+    }),
+    (name, version, {
+        'patches': [
+            'TensorFlow-1.14.0_swig-env.patch',
+            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
+        ],
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
+        'test_script': 'TensorFlow-2.x_mnist-test.py',
+        'checksums': [
+            '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
+            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
+            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
+            '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
+        ],
+    }),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb
@@ -1,0 +1,144 @@
+easyblock = 'PythonBundle'
+
+name = 'TensorFlow'
+version = '2.2.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://www.tensorflow.org/'
+description = "An open-source software library for Machine Intelligence"
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+builddependencies = [
+    ('Bazel', '2.0.0'),
+    # git 2.x required, see also https://github.com/tensorflow/tensorflow/issues/29053
+    ('git', '2.23.0', '-nodocs'),
+    # For SciPy
+    ('pybind11', '2.4.3', versionsuffix),
+]
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
+    ('cuDNN', '7.6.4.38'),
+    ('NCCL', '2.4.8'),
+]
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'sanity_pip_check': True,
+}
+use_pip = True
+
+exts_list = [
+    ('scipy', '1.4.1', {
+        'patches': ['scipy-1.4.1-fix-pthread.patch'],
+        'checksums': [
+            'dee1bbf3a6c8f73b6b218cb28eed8dd13347ea2f87d572ce19b289d6fd3fbc59',  # scipy-1.4.1.tar.gz
+            '4e2162a93caddce63a1aa2dfb6c181774a4f6615950e1d60c54bb4308fee3bb3',  # scipy-1.4.1-fix-pthread.patch
+        ],
+    }),
+    ('Markdown', '3.2.1', {
+        'checksums': ['90fee683eeabe1a92e149f7ba74e5ccdc81cd397bd6c516d93a8da0ef90b6902'],
+    }),
+    ('pyasn1-modules', '0.2.8', {
+        'modulename': 'pyasn1_modules',
+        'checksums': ['905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e'],
+    }),
+    ('rsa', '4.0', {
+        'checksums': ['1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487'],
+    }),
+    ('cachetools', '4.1.0', {
+        'checksums': ['1d057645db16ca7fe1f3bd953558897603d6f0b9c51ed9d11eb4d071ec4e2aab'],
+    }),
+    ('google-auth', '1.14.2', {
+        'modulename': 'google.auth',
+        'checksums': ['2243db98475f7f2033c41af5185333cbf13780e8f5f96eaadd997c6f34181dcc'],
+    }),
+    ('oauthlib', '3.1.0', {
+        'checksums': ['bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889'],
+    }),
+    ('requests-oauthlib', '1.3.0', {
+        'modulename': 'requests_oauthlib',
+        'checksums': ['b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a'],
+    }),
+    ('google-auth-oauthlib', '0.4.1', {
+        'modulename': 'google_auth_oauthlib',
+        'checksums': ['88d2cd115e3391eb85e1243ac6902e76e77c5fe438b7276b297fbe68015458dd'],
+    }),
+    ('Werkzeug', '1.0.1', {
+        'checksums': ['6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c'],
+    }),
+    ('protobuf', '3.11.3', {
+        'modulename': 'google.protobuf',
+        'checksums': ['c77c974d1dadf246d789f6dad1c24426137c9091e930dbf50e0a29c1fcf00b1f'],
+    }),
+    ('absl-py', '0.9.0', {
+        'modulename': 'absl',
+        'checksums': ['75e737d6ce7723d9ff9b7aa1ba3233c34be62ef18d5859e706b8fdc828989830'],
+    }),
+    ('astunparse', '1.6.3', {
+        'checksums': ['5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872'],
+    }),
+    ('grpcio', '1.28.1', {
+        'modulename': 'grpc',
+        'checksums': ['cbc322c5d5615e67c2a15be631f64e6c2bab8c12505bc7c150948abdaa0bdbac'],
+    }),
+    ('tensorboard-plugin-wit', '1.6.0.post3', {
+        'source_tmpl': 'tensorboard_plugin_wit-%(version)s-py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['1fdf4ac343f1665453205aef8bb227b0204893bb5ffb792d2ed4509b1daf3d4f'],
+    }),
+    ('tensorboard', '2.2.1', {
+        'source_tmpl': 'tensorboard-%(version)s-py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['9a2a2dc9856187679e93f3c95e5dc771dd47e3257db09767b4be118d734b4dc2'],
+    }),
+    ('google-pasta', '0.2.0', {
+        'modulename': 'pasta',
+        'checksums': ['c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e'],
+    }),
+    ('termcolor', '1.1.0', {
+        'checksums': ['1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b'],
+    }),
+    ('tensorflow-estimator', version, {
+        'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
+        'unpack_sources': False,
+        'checksums': ['d09dacdd127f2579cea8d5af21f4a918036b8ae246adc82f26b61f91cc247dc2'],
+    }),
+    ('gast', '0.3.3', {
+        'checksums': ['b881ef288a49aa81440d2c5eb8aeefd4c2bb8993d5f50edae7413a85bfdb3b57'],
+    }),
+    ('opt-einsum', '3.2.1', {
+        'source_tmpl': 'opt_einsum-%(version)s.tar.gz',
+        'checksums': ['83b76a98d18ae6a5cc7a0d88955a7f74881f0e567a0f4c949d24c942753eb998'],
+    }),
+    ('wrapt', '1.12.1', {
+        'checksums': ['b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7'],
+    }),
+    ('Keras-Preprocessing', '1.1.0', {
+        'modulename': 'keras_preprocessing',
+        'source_tmpl': 'Keras_Preprocessing-%(version)s.tar.gz',
+        'checksums': ['5a8debe01d840de93d49e05ccf1c9b81ae30e210d34dacbcc47aeb3049b528e5'],
+    }),
+    (name, version, {
+        'patches': [
+            'TensorFlow-1.14.0_swig-env.patch',
+            'TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch',
+            'TensorFlow-2.1.0_fix-cuda-build.patch',
+        ],
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/tensorflow/tensorflow/archive/'],
+        'test_script': 'TensorFlow-2.x_mnist-test.py',
+        'checksums': [
+            '69cd836f87b8c53506c4f706f655d423270f5a563b76dc1cfa60fbc3184185a3',  # v2.2.0.tar.gz
+            'b83cce6b91c7d19b8b320158ffc50fb4b2de454f5ac191c58d704234a1bf9005',  # TensorFlow-1.14.0_swig-env.patch
+            # TensorFlow-1.14.0_remove_usrbin_from_linker_bin_path_flag.patch
+            'bfa2701495dddfbbf4fbec808ea3c982b50043a16d28a8d1283f44df0b8aae7d',
+            '78c20aeaa7784b8ceb46238a81e8c2461137d28e0b576deeba8357d23fbe1f5a',  # TensorFlow-2.1.0_fix-cuda-build.patch
+        ],
+    }),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/scipy-1.4.1-fix-pthread.patch
+++ b/easybuild/easyconfigs/t/TensorFlow/scipy-1.4.1-fix-pthread.patch
@@ -1,0 +1,39 @@
+From https://github.com/scipy/scipy/pull/11324
+Author: Peter Bell <peterbell10@live.co.uk>
+diff --git a/scipy/fft/_pocketfft/setup.py b/scipy/fft/_pocketfft/setup.py
+index a4411bdedb1..493387d9719 100644
+--- a/scipy/fft/_pocketfft/setup.py
++++ b/scipy/fft/_pocketfft/setup.py
+@@ -5,20 +5,28 @@ def pre_build_hook(build_ext, ext):
+     cc = build_ext._cxx_compiler
+     args = ext.extra_compile_args
+ 
+-    std_flag = get_cxx_std_flag(build_ext._cxx_compiler)
++    std_flag = get_cxx_std_flag(cc)
+     if std_flag is not None:
+         args.append(std_flag)
+ 
+     if cc.compiler_type == 'msvc':
+         args.append('/EHsc')
+     else:
+-        try_add_flag(args, cc, '-fvisibility=hidden')
+-
++        # Use pthreads if available
+         has_pthreads = try_compile(cc, code='#include <pthread.h>\n'
+                                    'int main(int argc, char **argv) {}')
+         if has_pthreads:
+             ext.define_macros.append(('POCKETFFT_PTHREADS', None))
+-
++            if has_flag(cc, '-pthread'):
++                args.append('-pthread')
++                ext.extra_link_args.append('-pthread')
++            else:
++                raise RuntimeError("Build failed: System has pthreads header "
++                                   "but could not compile with -pthread option")
++
++        # Don't export library symbols
++        try_add_flag(args, cc, '-fvisibility=hidden')
++        # Set min macOS version
+         min_macos_flag = '-mmacosx-version-min=10.9'
+         import sys
+         if sys.platform == 'darwin' and has_flag(cc, min_macos_flag):

--- a/easybuild/easyconfigs/z/Zip/Zip-3.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/z/Zip/Zip-3.0-GCCcore-8.3.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'Zip'
+version = '3.0'
+
+homepage = 'http://www.info-zip.org/Zip.html'
+description = """Zip is a compression and file packaging/archive utility.
+Although highly compatible both with PKWARE's PKZIP and PKUNZIP
+utilities for MS-DOS and with Info-ZIP's own UnZip, our primary objectives
+have been portability and other-than-MSDOS functionality"""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://download.sourceforge.net/infozip']
+sources = ['%(namelower)s%(version_major)s%(version_minor)s.tar.gz']
+checksums = ['f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369']
+
+builddependencies = [
+    ('binutils', '2.32'),
+]
+dependencies = [
+    ('bzip2', '1.0.8'),
+]
+
+skipsteps = ['configure']
+
+buildopts = '-f unix/Makefile CC="$CC" IZ_OUR_BZIP2_DIR=$EBROOTBZIP2 '
+buildopts += 'CFLAGS="$CFLAGS -I. -DUNIX -DBZIP2_SUPPORT -DUNICODE_SUPPORT -DLARGE_FILE_SUPPORT" '
+buildopts += 'generic_gcc'
+
+installopts = '-f unix/Makefile prefix=%(installdir)s '
+
+sanity_check_paths = {
+    'files': ['bin/zip', 'bin/zipcloak', 'bin/zipnote', 'bin/zipsplit'],
+    'dirs': ['man/man1']
+}
+
+sanity_check_commands = ["zip --version"]
+
+moduleclass = 'tools'


### PR DESCRIPTION
For INC1045579

* [x] Assigned to reviewer

* [x] Bazel EasyBlock update: https://github.com/bear-rsg/easybuild-easyblocks/pull/33

All of this is from upstream, with one change - to have Bazel use Java 11 (instead of 1.8).

`TensorFlow-2.2.0-foss-2019b-Python-3.7.4.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-power9
* [ ] Ubuntu16 VM

`TensorFlow-2.2.0-fosscuda-2019b-Python-3.7.4.eb`
* [ ] EL7-haswell
* [ ] EL7-power9
