### PR TITLE
aenet update

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.19.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.19.1-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,61 @@
+easyblock = 'PythonBundle'
+
+name = 'ASE'
+version = '3.19.1'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://wiki.fysik.dtu.dk/ase'
+description = """ASE is a python package providing an open source Atomic Simulation Environment
+ in the Python scripting language."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('Tkinter', '%(pyver)s'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('matplotlib', '3.1.1', versionsuffix),
+]
+
+use_pip = True
+
+exts_list = [
+    ('MarkupSafe', '1.1.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/M/MarkupSafe'],
+        'checksums': ['29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b'],
+    }),
+    ('Jinja2', '2.11.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/J/Jinja2'],
+        'checksums': ['89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0'],
+    }),
+    ('Werkzeug', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/W/Werkzeug'],
+        'checksums': ['6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c'],
+    }),
+    ('Click', '7.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/C/Click'],
+        'checksums': ['5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7'],
+    }),
+    ('itsdangerous', '1.1.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/i/itsdangerous'],
+        'checksums': ['321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19'],
+    }),
+    ('Flask', '1.1.2', {
+        'source_urls': ['https://pypi.python.org/packages/source/F/Flask'],
+        'checksums': ['4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060'],
+    }),
+    ('ase', version, {
+        'source_urls': ['https://pypi.python.org/packages/source/a/ase'],
+        'checksums': ['839029ed5ad9590b40c74773b9aef4733bfd9f8300cf998011584cad6ebdbf0f'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/ase'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+# make sure Tkinter is available, otherwise 'ase gui' will not work
+sanity_check_commands = ["python -c 'import tkinter' "]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/a/aenet/aenet-2.0.4-foss-2019b-gfortran_openblas_mpi.eb
+++ b/easybuild/easyconfigs/a/aenet/aenet-2.0.4-foss-2019b-gfortran_openblas_mpi.eb
@@ -4,8 +4,8 @@ easyblock = 'ConfigureMake'
 
 name = 'aenet'
 version = '2.0.4'
-versionsuffix = '-Python-%(pyver)s'
-_makefilever = 'gfortran_openblas_serial'
+_makefilever = 'gfortran_openblas_mpi'
+versionsuffix = '-%s' % _makefilever
 _file_ext = '-%%(version)s-%s' % _makefilever
 
 homepage = "https://github.com/atomisticnet/aenet"
@@ -26,13 +26,7 @@ checksums = [
     'ef23a5ffe5e1a39f1c53ad0881a7e3254a2638f557ace3d93ad9b8ba54734148',  # aenet-2.0.4_lblas_llapack.patch
 ]
 
-dependencies = [
-    ('Python', '3.7.4'),
-    ('SciPy-bundle', '2019.10', versionsuffix),
-    ('ASE', '3.19.1', versionsuffix),
-]
-
-skipsteps = ['configure']
+skipsteps = ['configure', 'install']
 
 buildininstalldir = True
 
@@ -40,8 +34,6 @@ prebuildopts = "cd lib && make && "
 
 build_cmd = "cd ../src && make -f makefiles/Makefile.%s && " % _makefilever
 build_cmd += "make lib -f makefiles/Makefile.%s" % _makefilever
-
-install_cmd = "cd python3 && pip install -e ."
 
 sanity_check_paths = {
     'files': [
@@ -55,8 +47,6 @@ sanity_check_paths = {
         '%%(name)s-%%(version)s/%s' % x for x in ['doc', 'lib', 'examples', 'src', 'tools']
     ],
 }
-
-sanity_check_commands = ["python -c 'import aenet'"]
 
 modextrapaths = {
     'PATH': '%(name)s-%(version)s/bin',

--- a/easybuild/easyconfigs/a/aenet/aenet-2.0.4-foss-2019b-mpi.eb
+++ b/easybuild/easyconfigs/a/aenet/aenet-2.0.4-foss-2019b-mpi.eb
@@ -5,7 +5,7 @@ easyblock = 'ConfigureMake'
 name = 'aenet'
 version = '2.0.4'
 _makefilever = 'gfortran_openblas_mpi'
-versionsuffix = '-%s' % _makefilever
+versionsuffix = '-mpi'
 _file_ext = '-%%(version)s-%s' % _makefilever
 
 homepage = "https://github.com/atomisticnet/aenet"


### PR DESCRIPTION
For INC1046505

Update for #238. It seems as though the python interface only works with the serial version of aenet, and with the new build / install commands (see http://ann.atomistic.net/forum/?place=msg%2Faenet%2FMioTk2EgZC4%2FvwdukO6wCgAJ). I have updated the original easyconfig to use the serial Makefile. ASE is also needed for the Python interface. 

I have also made a new easyconfig for the MPI version, without installing the Python interface.

* [x] Assigned to reviewer

aenet-2.0.4-foss-2019b-Python-3.7.4.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell

aenet-2.0.4-foss-2019b-gfortran_openblas_mpi.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell