### PR TITLE
texlive

### DIFF
--- a/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.58.3-GCCcore-8.3.0-Python-2.7.16.eb
+++ b/easybuild/easyconfigs/g/GObject-Introspection/GObject-Introspection-1.58.3-GCCcore-8.3.0-Python-2.7.16.eb
@@ -1,0 +1,47 @@
+easyblock = 'ConfigureMake'
+
+name = 'GObject-Introspection'
+version = '1.58.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://wiki.gnome.org/GObjectIntrospection/'
+description = """GObject introspection is a middleware layer between C libraries
+ (using GObject) and language bindings. The C library can be scanned at
+ compile time and generate a metadata file, in addition to the actual
+ native C library. Then at runtime, language bindings can read this
+ metadata and automatically provide bindings to call into the C library."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [FTPGNOME_SOURCE]
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['025b632bbd944dcf11fc50d19a0ca086b83baf92b3e34936d008180d28cdc3c8']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('Autotools', '20180311'),
+    ('flex', '2.6.4'),
+    ('Bison', '3.3.2'),
+    ('cairo', '1.16.0'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('Python', '2.7.16'),
+    ('GLib', '2.62.0'),
+    ('libffi', '3.2.1'),
+    ('util-linux', '2.34'),
+]
+
+preconfigopts = "env GI_SCANNER_DISABLE_CACHE=true "
+
+# avoid using hard-coded path to 'python' in shebang of scripts
+buildopts = "PYTHON=python"
+
+sanity_check_paths = {
+    'files': ['bin/g-ir-%s' % x for x in ['annotation-tool', 'compiler', 'generate', 'scanner']] +
+             ['lib/libgirepository-1.0.%s' % x for x in [SHLIB_EXT, 'a']],
+    'dirs': ['include', 'share']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/g/graphite2/graphite2-1.3.14-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/graphite2/graphite2-1.3.14-GCCcore-8.3.0.eb
@@ -18,4 +18,10 @@ builddependencies = [
     ('binutils', '2.32'),
 ]
 
+sanity_check_paths = {
+    'files': ['bin/gr2fonttest'] +
+             ['lib/lib%%(name)s.%s' % x for x in [SHLIB_EXT, 'la']],
+    'dirs': ['include/%(name)s', 'share']
+}
+
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/graphite2/graphite2-1.3.14-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/graphite2/graphite2-1.3.14-GCCcore-8.3.0.eb
@@ -1,0 +1,21 @@
+easyblock = 'CMakeMake'
+
+name = 'graphite2'
+version = '1.3.14'
+
+homepage = 'https://scripts.sil.org/cms/scripts/page.php?site_id=projects&item_id=graphite_home'
+description = """Graphite is a "smart font" system developed specifically to
+ handle the complexities of lesser-known languages of the world."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/silnrsi/graphite/archive/']
+sources = ['%(version)s.zip']
+checksums = ['36e15981af3bf7a3ca3daf53295c8ffde04cf7d163e3474e4d0836e2728b4149']
+
+builddependencies = [
+    ('CMake', '3.15.3'),
+    ('binutils', '2.32'),
+]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/poppler/poppler-0.90.1-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/poppler/poppler-0.90.1-foss-2019b.eb
@@ -1,0 +1,53 @@
+# easybuild easyconfig
+#
+# John Dey jfdey@fredhutch.org
+# Fred Hutchinson Cancer Research Center Seattle WA USA
+
+easyblock = 'CMakeMake'
+
+name = 'poppler'
+version = '0.90.1'
+
+homepage = 'https://poppler.freedesktop.org/'
+description = """Poppler is a PDF rendering library based on the xpdf-3.0 code
+ base."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://poppler.freedesktop.org/']
+sources = [SOURCELOWER_TAR_XZ]
+checksums = ['984d82e72e91418d280885298c8bdc855a2fd92665fd52a1345b27235e0c71c4']
+
+separate_build_dir = True
+
+builddependencies = [
+    ('pkgconfig', '1.5.1', '-Python-2.7.16'),
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+    ('Qt5', '5.13.1'),
+    ('cairo', '1.16.0'),
+    ('GObject-Introspection', '1.58.3', '-Python-2.7.16'),
+    ('libjpeg-turbo', '2.0.3'),
+    ('libpng', '1.6.37'),
+    ('LibTIFF', '4.0.10'),
+    ('NSS', '3.45'),
+    ('OpenJPEG', '2.3.1'),
+]
+
+local_bin_files = ['pdfdetach', 'pdffonts', 'pdfimages', 'pdfinfo', 'pdfseparate',
+                   'pdftocairo', 'pdftohtml', 'pdftoppm', 'pdftops', 'pdftotext',
+                   'pdfunite']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_bin_files] +
+             ['lib/libpoppler.%s' % SHLIB_EXT,
+              'lib/libpoppler-cpp.%s' % SHLIB_EXT,
+              'lib/libpoppler-glib.%s' % SHLIB_EXT,
+              'include/poppler/glib/poppler.h'],
+    'dirs': ['bin',
+             'include',
+             'include/poppler/glib',
+             ]
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/texlive/texlive-20200406-foss-2019b.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20200406-foss-2019b.eb
@@ -5,7 +5,7 @@ easyblock = 'Tarball'
 name = 'texlive'
 version = '20200406'
 
-homepage = 'http://tug.org'
+homepage = 'https://tug.org'
 description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
  text intertwined with TeX commands in a plain text file. You then run TeX to produce formatted output, such as a
  PDF file. Thus, in contrast to standard word processors, your document is a separate file that does not pretend to

--- a/easybuild/easyconfigs/t/texlive/texlive-20200406-foss-2019b.eb
+++ b/easybuild/easyconfigs/t/texlive/texlive-20200406-foss-2019b.eb
@@ -1,0 +1,60 @@
+# Based off the upstream 2017 version by John Dey jfdey@fredhutch.org
+# https://github.com/easybuilders/easybuild-easyconfigs/pull/5085
+easyblock = 'Tarball'
+
+name = 'texlive'
+version = '20200406'
+
+homepage = 'http://tug.org'
+description = """TeX is a typesetting language. Instead of visually formatting your text, you enter your manuscript
+ text intertwined with TeX commands in a plain text file. You then run TeX to produce formatted output, such as a
+ PDF file. Thus, in contrast to standard word processors, your document is a separate file that does not pretend to
+ be a representation of the final typeset output, and so can be easily edited and manipulated."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['ftp://tug.org/texlive/historic/2020/']
+sources = [
+    {
+        'download_filename': 'install-tl-unx.tar.gz',
+        'filename': 'install-tl-unx-%(version)s.tar.gz',
+    }
+]
+checksums = ['7c90a50e55533d57170cbc7c0370a010019946eb18570282948e1af6f809382d']
+
+dependencies = [
+    ('X11', '20190717'),
+    ('libpng', '1.6.37'),
+    ('libGLU', '9.0.1'),
+    ('Perl', '5.30.0'),
+    ('HarfBuzz', '2.6.4'),
+    ('poppler', '0.90.1'),
+    ('cairo', '1.16.0'),
+    ('fontconfig', '2.13.1'),
+    ('zlib', '1.2.11'),
+    ('graphite2', '1.3.14'),
+]
+
+postinstallcmds = [
+    'echo "TEXDIR         %(installdir)s/" > %(installdir)s/texlive.profile && '
+    'echo "TEXMFLOCAL     %(installdir)s/texmf-local" >> %(installdir)s/texlive.profile && '
+    'echo "TEXMFSYSCONFIG %(installdir)s/texmf-config" >> %(installdir)s/texlive.profile && '
+    'echo "TEXMFSYSVAR    %(installdir)s/texmf-var" >> %(installdir)s/texlive.profile && '
+    '%(builddir)s/install-tl-%(version)s/install-tl -profile %(installdir)s/texlive.profile'
+]
+
+modextrapaths = {
+    'PATH': 'bin/x86_64-linux',
+    'INFOPATH': 'texmf-dist/doc/info',
+    'MANPATH': 'texmf-dist/doc/man',
+}
+modextravars = {
+    'TEXMFHOME': '%(installdir)s/texmf-dist'
+}
+
+sanity_check_paths = {
+    'files': ['bin/x86_64-linux/tex', 'bin/x86_64-linux/latex'],
+    'dirs': ['bin/x86_64-linux', 'texmf-dist'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
For INC1057165

All ecs are from upstream or direct updates of exisitng items.

https://bear-apps.bham.ac.uk/applications/orca/1.3.0-GCCcore-8.3.0/ requires this for some functionality - not sure if we want to make it a dep there, as that will involve moving orca to the foss toolchain. We might want to just note it on the orca webpage.

`texlive-20200406-foss-2019b.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
