### PR TITLE
cf-python 3.4.0 and cf-plot 3.0.6

### DIFF
--- a/easybuild/easyconfigs/b/BEAR-Python-Sciences/BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/b/BEAR-Python-Sciences/BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb
@@ -38,6 +38,8 @@ dependencies = [
     ('Cartopy', '0.18.0', versionsuffix),
     ('basemap', '1.2.1', versionsuffix),
     ('geopandas', '0.8.1', versionsuffix),
+    ('cf-python', '3.4.0', versionsuffix),
+    ('cf-plot', '3.0.6', versionsuffix),
 ]
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/c/cf-plot/cf-plot-3.0.6-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/c/cf-plot/cf-plot-3.0.6-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,37 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'cf-plot'
+version = '3.0.6'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://ajheaps.github.io/cf-plot/"
+description = """cf-plot is a set of Python routines for making the common contour, vector and line
+ plots that climate researchers use. The data to make a contour plot can be passed to cf-plot using
+ cf-python as in the following example."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('matplotlib', '3.1.1', versionsuffix),
+    ('Cartopy', '0.18.0', versionsuffix),
+    ('cf-python', '3.4.0', versionsuffix)
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    (name, version, {
+        'modulename': 'cfplot',
+        'checksums': ['f8eb05875b5739f497a23503b9d8a9f7f7153ab6eada28f57ff9d48def268064'],
+    }),
+]
+
+moduleclass = 'geo'

--- a/easybuild/easyconfigs/c/cf-python/cf-python-3.4.0-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/c/cf-python/cf-python-3.4.0-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,41 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'cf-python'
+version = '3.4.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://ncas-cms.github.io/cf-python/"
+description = """The Python cf package is an Earth Science data analysis library that is built on a
+ complete implementation of the CF data model."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('netcdf4-python', '1.5.3', versionsuffix),
+    ('UDUNITS', '2.2.26')
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('cfunits', '3.2.6', {
+        'checksums': ['3fdbb0473f972a19ff3dd36d6d1302733f03a1ad9e0e86e421f58116c2b1ae28'],
+    }),
+    ('cfdm', '1.8.3', {
+        'checksums': ['805405c43922effefe2afc054b5a36d7c43bc4aa0bc68d90cb648bbb9f534afa'],
+    }),
+    (name, version, {
+        'modulename': 'cf',
+        'checksums': ['d7622d60357811599352a31cce9d8055ed82fc3710db498ee2d376d52726d50a'],
+    }),
+]
+
+moduleclass = 'geo'


### PR DESCRIPTION
For INC1058351

cf-python version 3.4.0 used to make it compatible with netcdf4-python 1.5.3 / cftime 1.1.1.2.

cf-plot version 3.0.6 used as newer versions require scipy >= 1.4.0.

* [x] Assigned to reviewer

cf-python-3.4.0-foss-2019b-Python-3.7.4.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell


cf-plot-3.0.6-foss-2019b-Python-3.7.4.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell

BEAR-Python-Sciences-2019b-foss-2019b-Python-3.7.4.eb
* [ ] EL7-cascadelake
* [ ] EL7-haswell