### PR TITLE
fixed clingo

### DIFF
--- a/easybuild/easyconfigs/c/clingo/clingo-5.4.0-GCCcore-8.3.0-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/c/clingo/clingo-5.4.0-GCCcore-8.3.0-Python-3.7.4.eb
@@ -28,15 +28,10 @@ dependencies = [
     ('re2c', '1.2.1'),
 ]
 
-preconfigopts = 'mkdir build && cd build && '
-configure_cmd = 'cmake ..'
 configopts = '-DLIB_POTASSCO_INSTALL_LIB=ON '
 configopts += '-DCLASP_BUILD_APP=ON'
-prebuildopts = 'cd build && '
 
-files_to_copy = [
-    'build/*'
-]
+files_to_copy = ['*']
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in ['%(name)s', 'clasp', 'lpconvert',


### PR DESCRIPTION
For INC1063875

Update for #291 (removed `preconfigopts = "mkdir build && cd build && "`).

clingo-5.4.0-GCCcore-8.3.0-Python-3.7.4.eb
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell