### PR TITLE
Remove licence server definition

### DIFF
--- a/easybuild/easyconfigs/h/HEXPRESS/HEXPRESS-8.1.eb
+++ b/easybuild/easyconfigs/h/HEXPRESS/HEXPRESS-8.1.eb
@@ -21,11 +21,6 @@ sanity_check_paths = {
     'dirs': [],
 }
 
-# Add our license servers
-modextravars = {
-    'NUMECA_LICENSE_FILE': '27023@lic-server1.bham.ac.uk:27023@lic-server2.bham.ac.uk:27023@lic-server3.bham.ac.uk'
-}
-
 dependencies = [
     ('libpng', '1.2.58'),
 ]


### PR DESCRIPTION
Moving licence server env var to licences module:
https://gitlab.bham.ac.uk/res-comp-team/system-modules/-/merge_requests/42

`eb HEXPRESS-8.1.eb --module-only`

* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
