### PR TITLE
Longshot

### DIFF
--- a/easybuild/easyconfigs/l/Longshot/Longshot-0.4.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/Longshot/Longshot-0.4.1-GCCcore-8.3.0.eb
@@ -1,0 +1,38 @@
+# This easyconfig was created by Simon Branford of the BEAR Software team at the University of Birmingham.
+easyblock = 'Binary'
+
+name = 'Longshot'
+version = '0.4.1'
+
+homepage = 'https://github.com/pjedge/longshot'
+description = """Longshot is a variant calling tool for diploid genomes using long error prone reads such as Pacific
+ Biosciences (PacBio) SMRT and Oxford Nanopore Technologies (ONT). It takes as input an aligned BAM file and outputs
+ a phased VCF file with variants and haplotype information. It can also output haplotype-separated BAM files that can
+ be used for downstream analysis. Currently, it only calls single nucleotide variants (SNVs)."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://github.com/pjedge/longshot/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['062529eb47fafc2ef4a1a12ea30a565a0df922b310b6fc5705a1605ce4f495f3']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('Rust', '1.42.0'),
+    ('Clang', '9.0.1'),
+    ('zlib', '1.2.11'),
+    ('XZ', '5.2.4'),
+]
+
+extract_sources = True
+
+install_cmd = "cargo install --root %(installdir)s --path ."
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["%(namelower)s --help"]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/Rust/Rust-1.42.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/r/Rust/Rust-1.42.0-GCCcore-8.3.0.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'Rust'
+version = '1.42.0'
+
+homepage = 'https://www.rust-lang.org'
+description = """Rust is a systems programming language that runs blazingly fast, prevents segfaults,
+ and guarantees thread safety."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://static.rust-lang.org/dist/']
+sources = ['rustc-%(version)s-src.tar.gz']
+checksums = ['d2e8f931d16a0539faaaacd801e0d92c58df190269014b2360c6ab2a90ee3475']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+
+configopts = "--enable-extended --sysconfdir=%(installdir)s/etc"
+
+sanity_check_paths = {
+    'files': ['bin/cargo', 'bin/rustc', 'bin/rustdoc'],
+    'dirs': ['lib/rustlib', 'share/doc', 'share/man'],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
EL8/U20 replacement, but may as well add it to EL7/U16

`Longshot-0.4.1-GCCcore-8.3.0.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20
