### PR TITLE
MetaXcan

### DIFF
--- a/easybuild/easyconfigs/a/almosthere/almosthere-1.0.10-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/a/almosthere/almosthere-1.0.10-GCCcore-8.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'almosthere'
+version = '1.0.10'
+
+homepage = "https://github.com/horta/almosthere"
+description = """Progress indicator C library.
+
+ATHR is a simple yet powerful progress indicator library that works on Windows, 
+Linux, and macOS. It is non-blocking as the progress update is done via a 
+dedicated, lightweight thread, as to not impair the performance of the calling program."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+toolchainopts = {'pic': True}
+
+
+github_account = 'horta'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['36e943f6e76fba6d2638972aff71d767a5ba0e72c472acf8282729ef1b0a0a0d']
+configopts = '-DBUILD_SHARED_LIBS=ON'
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/libathr.%s' % SHLIB_EXT, 'include/athr.h'],
+    'dirs': ['lib/cmake']
+}
+
+separate_build_dir = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/limix-bgen/limix-bgen-3.0.3-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/limix-bgen/limix-bgen-3.0.3-GCCcore-8.3.0.eb
@@ -1,0 +1,35 @@
+easyblock = 'CMakeMake'
+
+name = 'limix-bgen'
+version = '3.0.3'
+
+homepage = "https://github.com/limix/bgen"
+description = """A BGEN file format reader.
+
+It fully supports the BGEN format specifications 1.2 and 1.3."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+github_account = 'limix'
+source_urls = ['https://github.com/limix/bgen/archive/']
+sources = ['%(version)s.tar.gz']
+checksums = ['1cf434f35aaee86d1093f1fd96caf07fa92c3b49a760175052af934d74e702a6']
+
+builddependencies = [
+    ('binutils', '2.32'),
+    ('CMake', '3.15.3'),
+]
+dependencies = [
+    ('almosthere', '1.0.10'),
+    ('zstd', '1.4.4')
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/libbgen.%s' % SHLIB_EXT, 'include/bgen.h'],
+    'dirs': ['include/bgen']
+}
+
+separate_build_dir = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
@@ -37,6 +37,7 @@ exts_list = [
     }),
     ('pytest-runner', '5.2', {
         'checksums': ['96c7e73ead7b93e388c5d614770d2bae6526efd997757d3543fe17b557a0942b'],
+        'modulename': 'ptr',
     }),
     ('texttable', '1.6.3', {
         'checksums': ['ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436'],
@@ -65,6 +66,7 @@ exts_list = [
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/hakyimlab/MetaXcan/archive/'],
         'checksums': ['c46fddd645529cc8c7744ad755364e84d55b00ffd2d699222a206c53c60c9e1d'],
+        'modulename': 'metax',
     }),
 ]
 

--- a/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
@@ -15,6 +15,7 @@ toolchainopts = {'pic': True, 'lowopt': True}  # match SciPy-bundle
 dependencies = [
     ('Python', '3.7.4'),
     ('limix-bgen', '3.0.3'),
+    ('cURL', '7.66.0'),
     ('SciPy-bundle', '2019.10', versionsuffix),
     ('statsmodels', '0.11.0', versionsuffix),
     ('h5py', '2.10.0', versionsuffix),

--- a/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
@@ -10,6 +10,7 @@ description = """MetaXcan is a set of tools to integrate genomic information of 
  traits."""
 
 toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': True, 'lowopt': True}  # match SciPy-bundle
 
 dependencies = [
     ('Python', '3.7.4'),

--- a/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/m/MetaXcan/MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb
@@ -1,0 +1,71 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonBundle'
+
+name = 'MetaXcan'
+version = '0.7.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://github.com/hakyimlab/MetaXcan"
+description = """MetaXcan is a set of tools to integrate genomic information of biological mechanisms with complex
+ traits."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('Python', '3.7.4'),
+    ('limix-bgen', '3.0.3'),
+    ('SciPy-bundle', '2019.10', versionsuffix),
+    ('statsmodels', '0.11.0', versionsuffix),
+    ('h5py', '2.10.0', versionsuffix),
+    ('tqdm', '4.41.1'),
+    ('dask', '2.8.0', versionsuffix),
+    ('xarray', '0.15.1', versionsuffix),
+]
+
+sanity_pip_check = True
+use_pip = True
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('cachetools', '4.1.1', {
+        'checksums': ['bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20'],
+    }),
+    ('pytest-runner', '5.2', {
+        'checksums': ['96c7e73ead7b93e388c5d614770d2bae6526efd997757d3543fe17b557a0942b'],
+    }),
+    ('texttable', '1.6.3', {
+        'checksums': ['ce0faf21aa77d806bbff22b107cc22cce68dc9438f97a2df32c93e9afa4ce436'],
+    }),
+    ('bgen-reader', '3.0.7', {
+        'checksums': ['c21ef8c19e97d55a5c624ca43019068e57f4a39e83e26d38acb7cc1cccbe0e76'],
+    }),
+    ('humanfriendly', '8.2', {
+        'checksums': ['bf52ec91244819c780341a3438d5d7b09f431d3f113a475147ac9b7b167a3d12'],
+    }),
+    ('coloredlogs', '14.0', {
+        'checksums': ['a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505'],
+    }),
+    ('cyvcf2', '0.20.9', {
+        'checksums': ['e05d4e970d9048b1b779054c33970a908bd4c639e8b681e0a93ef443fdb95b28'],
+    }),
+    ('h5py-cache', '1.0', {
+        'checksums': ['f3e09e58a98f25dba461029f3223224cbd7c4fe1ea2213eda69083757f182e11'],
+    }),
+    # MetaXcan requires scipy < 1.3
+    ('scipy', '1.2.3', {
+        'checksums': ['ecbe6413ca90b8e19f8475bfa303ac001e81b04ec600d17fa7f816271f7cca57'],
+    }),
+    (name, version, {
+        'preinstallopts': "cd software && ",
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/hakyimlab/MetaXcan/archive/'],
+        'checksums': ['c46fddd645529cc8c7744ad755364e84d55b00ffd2d699222a206c53c60c9e1d'],
+    }),
+]
+
+sanity_check_commands = ["%s --help" % x for x in ['cyvcf2', 'M01_covariances_correlations.py', 'SPrediXcan.py']]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1078403

almosthere and limix-bgen are from upstream but moved toolchain.

`MetaXcan-0.7.3-foss-2019b-Python-3.7.4.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM
