### PR TITLE
Snippy Java fix

### DIFF
--- a/easybuild/easyconfigs/s/snippy/snippy-4.6.0-foss-2019b-Perl-5.30.0.eb
+++ b/easybuild/easyconfigs/s/snippy/snippy-4.6.0-foss-2019b-Perl-5.30.0.eb
@@ -26,6 +26,7 @@ dependencies = [
     ('vt', '2187ff6'),
     ('SAMtools', '1.10'),
     ('BCFtools', '1.10.2'),
+    ('Java', '11', '', True),
 ]
 
 sanity_check_paths = {
@@ -34,5 +35,7 @@ sanity_check_paths = {
               'binaries/linux/bwa'],
     'dirs': [],
 }
+
+sanity_check_commands = ["snippy --check"]
 
 moduleclass = 'bio'


### PR DESCRIPTION
For INC1084846

To fix missing Java dep and include a sanity check command

Rebuild: `snippy-4.6.0-foss-2019b-Perl-5.30.0.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM
