### PR TITLE
FIxes GTK+ building on Ubuntu 20.04

### DIFF
--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -44,19 +44,22 @@ prebuildopts = ('export XDG_DATA_DIRS=${EBROOTGDKMINPIXBUF}/share:'
                 '${XDG_DATA_DIRS} && ')
 
 components = [
-    ('hicolor-icon-theme', '0.17', {
-        'source_urls': ['https://icon-theme.freedesktop.org/releases/'],
-        'checksums': ['317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8'],
-    }),
-    ('adwaita-icon-theme', '3.34.3', {
-        'source_urls': [FTPGNOME_SOURCE],
-        'checksums': ['e7c2d8c259125d5f35ec09522b88c8fe7ecf625224ab0811213ef0a95d90b908'],
-    }),
+    # We need to install GTK+ before the other components, as they depend on it
+    # otherwise they'll use the system gtk+ when installing, and can have symbol errors
     (name, version, {
         'source_urls': [FTPGNOME_SOURCE],
         'checksums': ['4c775c38cf1e3c534ef0ca52ca6c7a890fe169981af66141c713e054e68930a9'],
         'configopts': "--disable-silent-rules --disable-glibtest --enable-introspection=yes "
                       "--disable-visibility --disable-cups ",
+    }),
+    ('adwaita-icon-theme', '3.34.3', {
+        'source_urls': [FTPGNOME_SOURCE],
+        'checksums': ['e7c2d8c259125d5f35ec09522b88c8fe7ecf625224ab0811213ef0a95d90b908'],
+        'preconfigopts': "export PATH=%(installdir)/bin:${PATH} && ",
+    }),
+    ('hicolor-icon-theme', '0.17', {
+        'source_urls': ['https://icon-theme.freedesktop.org/releases/'],
+        'checksums': ['317484352271d18cbbcfac3868eab798d67fff1b8402e740baa6ff41d588a9d8'],
     }),
 ]
 

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -50,6 +50,7 @@ components = [
     (name, version, {
         'source_urls': [FTPGNOME_SOURCE],
         'checksums': ['4c775c38cf1e3c534ef0ca52ca6c7a890fe169981af66141c713e054e68930a9'],
+        'preconfigopts': 'export LDFLAGS="${LDFLAGS} -L${EBROOTLIBRSVG}/lib -lrsvg-2" && ',
         'configopts': "--disable-silent-rules --disable-glibtest --enable-introspection=yes "
                       "--disable-visibility --disable-cups ",
     }),

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -30,6 +30,7 @@ dependencies = [
     ('libepoxy', '1.5.4'),
     ('X11', '20190717'),
     ('FriBidi', '1.0.5'),
+    ('librsvg', '2.48.9'),
 ]
 
 default_easyblock = 'ConfigureMake'
@@ -52,10 +53,10 @@ components = [
         'configopts': "--disable-silent-rules --disable-glibtest --enable-introspection=yes "
                       "--disable-visibility --disable-cups ",
     }),
-    ('adwaita-icon-theme', '3.34.3', {
+    ('adwaita-icon-theme', '3.38.0', {
         'source_urls': [FTPGNOME_SOURCE],
-        'checksums': ['e7c2d8c259125d5f35ec09522b88c8fe7ecf625224ab0811213ef0a95d90b908'],
-        'preconfigopts': "export PATH=%(installdir)/bin:${PATH} && ",
+        'checksums': ['6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97'],
+        'preconfigopts': "export PATH=%(installdir)s/bin:${PATH} && ",
     }),
     ('hicolor-icon-theme', '0.17', {
         'source_urls': ['https://icon-theme.freedesktop.org/releases/'],

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -20,6 +20,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
     ('cairo', '1.16.0'),
     ('Perl', '5.30.0'),
+    ('librsvg', '2.48.9'),  #XXX if we let it install libpixbufloader-svg.so into Gdk-Pixbuf
 ]
 
 dependencies = [
@@ -30,7 +31,6 @@ dependencies = [
     ('libepoxy', '1.5.4'),
     ('X11', '20190717'),
     ('FriBidi', '1.0.5'),
-    ('librsvg', '2.48.9'),
 ]
 
 default_easyblock = 'ConfigureMake'
@@ -50,13 +50,13 @@ components = [
     (name, version, {
         'source_urls': [FTPGNOME_SOURCE],
         'checksums': ['4c775c38cf1e3c534ef0ca52ca6c7a890fe169981af66141c713e054e68930a9'],
-        'preconfigopts': 'export LDFLAGS="${LDFLAGS} -L${EBROOTLIBRSVG}/lib -lrsvg-2" && ',
+        'preconfigopts': 'export LDFLAGS="-L${EBROOTLIBRSVG}/lib -lrsvg-2 ${LDFLAGS}" && ',
         'configopts': "--disable-silent-rules --disable-glibtest --enable-introspection=yes "
                       "--disable-visibility --disable-cups ",
     }),
-    ('adwaita-icon-theme', '3.38.0', {
+    ('adwaita-icon-theme', '3.34.3', {
         'source_urls': [FTPGNOME_SOURCE],
-        'checksums': ['6683a1aaf2430ccd9ea638dd4bfe1002bc92b412050c3dba20e480f979faaf97'],
+        'checksums': ['e7c2d8c259125d5f35ec09522b88c8fe7ecf625224ab0811213ef0a95d90b908'],
         'preconfigopts': "export PATH=%(installdir)s/bin:${PATH} && ",
     }),
     ('hicolor-icon-theme', '0.17', {

--- a/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/GTK+/GTK+-3.24.13-GCCcore-8.3.0.eb
@@ -20,7 +20,7 @@ builddependencies = [
     ('pkg-config', '0.29.2'),
     ('cairo', '1.16.0'),
     ('Perl', '5.30.0'),
-    ('librsvg', '2.48.9'),  #XXX if we let it install libpixbufloader-svg.so into Gdk-Pixbuf
+    ('librsvg', '2.48.9'),
 ]
 
 dependencies = [

--- a/easybuild/easyconfigs/l/libcroco/libcroco-0.6.13-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/libcroco/libcroco-0.6.13-GCCcore-8.3.0.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'libcroco'
+version = '0.6.13'
+
+homepage = 'https://github.com/GNOME/libcroco'
+description = """Libcroco is a standalone css2 parsing and manipulation library."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['http://ftp.gnome.org/pub/GNOME/sources/libcroco/%(version_major_minor)s/']
+sources = [SOURCE_TAR_XZ]
+checksums = ['767ec234ae7aa684695b3a735548224888132e063f92db585759b422570621d4']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libxml2', '2.9.9'),
+    ('GLib', '2.62.0'),
+]
+
+sanity_check_paths = {
+    'files': ['bin/csslint-%(version_major_minor)s', 'lib/libcroco-%%(version_major_minor)s.%s' % SHLIB_EXT,
+              'lib/libcroco-%(version_major_minor)s.a'],
+    'dirs': ['include/libcroco-%(version_major_minor)s', 'share']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
@@ -23,12 +23,13 @@ dependencies = [
     ('cairo', '1.16.0'),
 ]
 
-preconfigopts = 'LDFLAGS="-L${EBROOTHARFBUZZ}/lib" '
+preconfigopts = 'LDFLAGS="-L${EBROOTHARFBUZZ}/lib ${LDFLAGS}" '
 
 # this loader wants to install in the directory of Gdk-Pixbuf itself, so disable
-configopts = '--disable-pixbuf-loader'
+# configopts = '--disable-pixbuf-loader'
 
-prebuildopts = 'export LD_FLAGS="-lhb" && '
+# needed for svg compatibility for things that link against -lrsvg-2
+#configopts += ' --enable-tools'
 
 sanity_check_paths = {
     'files': ['bin/rsvg-convert', 'lib/librsvg-%%(version_major)s.%s' % SHLIB_EXT, 'lib/librsvg-2.a'],

--- a/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
@@ -25,11 +25,11 @@ dependencies = [
 
 preconfigopts = 'LDFLAGS="-L${EBROOTHARFBUZZ}/lib ${LDFLAGS}" '
 
-# this loader wants to install in the directory of Gdk-Pixbuf itself, so disable
+# WARNING: This will install libpixbufloader-svg.{a,la,so} into
+# the live install dir for Gdk-Pixbuf: ${EBROOTGDKMINPIXBUF}/lib/gdk-pixbuf-2.0/2.10.0/loaders
+# This is needed to build adwaita-icon-theme in GTK+-3.24.13-GCCcore-8.3.0.eb
+# To prevent this behaviour, uncomment the following line:
 # configopts = '--disable-pixbuf-loader'
-
-# needed for svg compatibility for things that link against -lrsvg-2
-#configopts += ' --enable-tools'
 
 sanity_check_paths = {
     'files': ['bin/rsvg-convert', 'lib/librsvg-%%(version_major)s.%s' % SHLIB_EXT, 'lib/librsvg-2.a'],

--- a/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/l/librsvg/librsvg-2.48.9-GCCcore-8.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'librsvg'
+version = '2.48.9'
+
+homepage = 'https://wiki.gnome.org/action/show/Projects/LibRsvg'
+description = """librsvg is a library to render SVG files using cairo."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+sources = [SOURCE_TAR_XZ]
+source_urls = ['https://download.gnome.org/sources/librsvg/%(version_major_minor)s']
+
+builddependencies = [
+    ('Rust', '1.42.0'),
+    ('GObject-Introspection', '1.63.1', '-Python-3.7.4'),
+]
+
+dependencies = [
+    ('Gdk-Pixbuf', '2.38.2'),
+    ('libcroco', '0.6.13'),
+    ('Pango', '1.44.7'),
+    ('cairo', '1.16.0'),
+]
+
+preconfigopts = 'LDFLAGS="-L${EBROOTHARFBUZZ}/lib" '
+
+# this loader wants to install in the directory of Gdk-Pixbuf itself, so disable
+configopts = '--disable-pixbuf-loader'
+
+prebuildopts = 'export LD_FLAGS="-lhb" && '
+
+sanity_check_paths = {
+    'files': ['bin/rsvg-convert', 'lib/librsvg-%%(version_major)s.%s' % SHLIB_EXT, 'lib/librsvg-2.a'],
+    'dirs': ['include/librsvg-2.0', 'share']
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
For U20 installs

`GTK+-3.24.13-GCCcore-8.3.0.eb`
* [ ] Ubuntu20 VM

Details:

On an Ubuntu 20.04 box, trying to build GTK+-3.24.13-GCCcore-8.3.0.eb fails because the first component adwaita-icon-theme requires gtk-encode-symbolic-svg to install its svg files and the system one has symbol errors because of the versions we're building.

Solution - reorder components to build GTK+ first, then add it to the PATH in a preconfigopt for adwaita-icon-theme.  BUT - now this fails because the newly installed gtk-encode-symbolic-svg can't handle svg files.

This is because Gdk-Pixbuf-2.38.2-GCCcore-8.3.0.eb doesn't have libpixbufloader-svg.so

It turns out that librsvg-2.48.9-GCCcore-8.3.0.eb (a new file based on the old librsvg-2.40.15-intel-2016a.eb) is responsible for libpixbufloader-svg.so , which it wants to install directly into the installdir of Gdk-Pixbuf. And indeed, if you let it do that then this all works (I think)... But librsvg-2.48.9-GCCcore-8.3.0.eb has (quite rightly) got configopts = '--disable-pixbuf-loader' set, so it doesn't do that.
