### PR TITLE
fosscuda 2020a

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-11.0.2-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-11.0.2-GCC-9.3.0.eb
@@ -1,0 +1,17 @@
+easyblock = 'Bundle'
+name = 'CUDA'
+version = '11.0.2'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = {'name': 'GCC', 'version': '9.3.0'}
+
+dependencies = [('CUDAcore', '11.0.2', '', True)]
+
+altroot = 'CUDAcore'
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.0.2.eb
+++ b/easybuild/easyconfigs/c/CUDAcore/CUDAcore-11.0.2.eb
@@ -1,0 +1,25 @@
+easyblock = "EB_CUDA"
+name = 'CUDAcore'
+version = '11.0.2'
+local_nv_version = '450.51.05'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://developer.download.nvidia.com/compute/cuda/%(version)s/local_installers/']
+sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
+checksums = [
+    {
+        'cuda_%%(version)s_%s_linux.run' % local_nv_version:
+            '48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1',
+        'cuda_%%(version)s_%s_linux_ppc64le.run' % local_nv_version:
+            'db06d0f3fbf6f7aa1f106fc921ad1c86162210a26e8cb65b171c5240a3bf75da',
+    }
+]
+
+moduleclass = 'system'

--- a/easybuild/easyconfigs/c/Check/Check-0.15.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/c/Check/Check-0.15.2-GCCcore-9.3.0.eb
@@ -1,0 +1,37 @@
+easyblock = 'ConfigureMake'
+
+name = 'Check'
+version = '0.15.2'
+
+homepage = 'https://libcheck.github.io/check/'
+description = """
+Check is a unit testing framework for C. It features a simple interface for
+defining unit tests, putting little in the way of the developer. Tests are
+run in a separate address space, so both assertion failures and code errors
+that cause segmentation faults or other signals can be caught. Test results
+are reportable in the following: Subunit, TAP, XML, and a generic logging
+format."""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'libcheck'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['998d355294bb94072f40584272cf4424571c396c631620ce463f6ea97aa67d2e']
+
+builddependencies = [
+    ('binutils', '2.34'),
+    ('Autotools', '20180311'),
+    ('pkg-config', '0.29.2'),
+]
+
+preconfigopts = "autoreconf -f -i && "
+configopts = "--disable-build-docs"
+
+sanity_check_paths = {
+    'files': ['bin/checkmk', 'lib/libcheck.a', 'lib/libcheck.%s' % SHLIB_EXT],
+    'dirs': ['include', 'share']
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompic-2020a.eb
+++ b/easybuild/easyconfigs/f/FFTW/FFTW-3.3.8-gompic-2020a.eb
@@ -1,0 +1,17 @@
+name = 'FFTW'
+version = '3.3.8'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompic', 'version': '2020a'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303']
+
+runtest = 'check'
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/f/fosscuda/fosscuda-2020a.eb
+++ b/easybuild/easyconfigs/f/fosscuda/fosscuda-2020a.eb
@@ -1,0 +1,29 @@
+easyblock = 'Toolchain'
+
+name = 'fosscuda'
+version = '2020a'
+
+homepage = '(none)'
+description = """GCC based compiler toolchain __with CUDA support__, and including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = SYSTEM
+
+local_gccver = '9.3.0'
+
+# toolchain used to build fosscuda dependencies
+local_comp_mpi_tc = ('gompic', version)
+
+# compiler toolchain dependencies
+# We need GCC, CUDA and OpenMPI as explicit dependencies instead of
+# gompic toolchain because of toolchain preperation functions.
+dependencies = [
+    ('GCC', local_gccver),  # part of gompic
+    ('CUDA', '11.0.2', '', ('GCC', local_gccver)),  # part of gompic
+    ('OpenMPI', '4.0.5', '', ('gcccuda', version)),  # part of gompic
+    ('OpenBLAS', '0.3.9', '', ('GCC', local_gccver)),
+    ('FFTW', '3.3.8', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.1.0', '', local_comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/GDRCopy/GDRCopy-2.1-GCCcore-9.3.0-CUDA-11.0.2.eb
+++ b/easybuild/easyconfigs/g/GDRCopy/GDRCopy-2.1-GCCcore-9.3.0-CUDA-11.0.2.eb
@@ -1,0 +1,58 @@
+easyblock = 'ConfigureMake'
+
+name = 'GDRCopy'
+version = '2.1'
+local_cudaversion = '11.0.2'
+versionsuffix = '-CUDA-%s' % local_cudaversion
+
+homepage = 'https://github.com/NVIDIA/gdrcopy'
+description = "A low-latency GPU memory copy library based on NVIDIA GPUDirect RDMA technology."
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'NVIDIA'
+source_urls = [GITHUB_SOURCE]
+sources = ['%(version)s.tar.gz']
+checksums = ['cecc7dcc071107f77396f5553c9109790b6d2298ae29eb2dbbdd52b2a213e4ea']
+
+builddependencies = [
+    ('binutils', '2.34'),
+    ('Autotools', '20180311'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('CUDAcore', local_cudaversion, '', True),
+    ('Check', '0.15.2'),
+]
+
+# This easyconfig only installs the library and binaries of GDRCopy. Please
+# keep in mind that GDRCopy also needs the following kernel modules at runtime:
+#
+# 1. Kernel module for GDRCopy: improves Host to GPU communication
+#    https://github.com/NVIDIA/gdrcopy
+#    RPM: 'gdrcopy-kmod', DEB: 'gdrdrv-dkms'
+#    Requirements: version of GDRCopy kernel module (gdrdrv.ko) >= 2.0
+#
+# 2. (optional) Kernel module for GPUDirect RDMA: improves GPU to GPU communication
+#    https://github.com/Mellanox/nv_peer_memory
+#    RPM: 'nvidia_peer_memory'
+#    Requirements: Mellanox HCA with MLNX_OFED 2.1
+#
+# These kernel modules are not listed as system dependencies to lower the system
+# requirements to build this easyconfig, as they are not needed for the build.
+
+skipsteps = ['configure']
+
+local_envopts = "PREFIX=%(installdir)s CUDA=$EBROOTCUDACORE"
+prebuildopts = "PATH=$PATH:/sbin "  # ensures that ldconfig is found
+buildopts = "config lib exes %s" % local_envopts
+installopts = local_envopts
+
+sanity_check_paths = {
+    'files': ['bin/copybw', 'bin/copylat', 'bin/sanity', 'lib/libgdrapi.%s' % SHLIB_EXT],
+    'dirs': ['include'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/gcccuda/gcccuda-2020a.eb
+++ b/easybuild/easyconfigs/g/gcccuda/gcccuda-2020a.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'gcccuda'
+version = '2020a'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, along with CUDA toolkit."""
+
+toolchain = SYSTEM
+
+local_gcc_version = '9.3.0'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', local_gcc_version),
+    ('CUDA', '11.0.2', '', ('GCC', local_gcc_version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/gompic/gompic-2020a.eb
+++ b/easybuild/easyconfigs/g/gompic/gompic-2020a.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'gompic'
+version = '2020a'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain along with CUDA toolkit,
+ including OpenMPI for MPI support with CUDA features enabled."""
+
+toolchain = SYSTEM
+
+local_gccver = '9.3.0'
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCC', local_gccver),  # part of gcccuda
+    ('CUDA', '11.0.2', '', ('GCC', local_gccver)),  # part of gcccuda
+    ('OpenMPI', '4.0.5', '', ('gcccuda', version)),
+]
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/l/libfabric/libfabric-1.11.0-GCCcore-9.3.0.eb
@@ -1,0 +1,40 @@
+easyblock = 'ConfigureMake'
+
+name = 'libfabric'
+version = '1.11.0'
+
+homepage = 'https://ofiwg.github.io/libfabric/'
+description = """
+Libfabric is a core component of OFI. It is the library that defines and exports
+the user-space API of OFI, and is typically the only software that applications
+deal with directly. It works in conjunction with provider libraries, which are
+often integrated directly into libfabric.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+github_account = 'ofiwg'
+source_urls = ['https://github.com/ofiwg/%(name)s/releases/download/v%(version)s']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['9938abf628e7ea8dcf60a94a4b62d499fbc0dbc6733478b6db2e6a373c80d58f']
+
+builddependencies = [
+    ('binutils', '2.34'),
+    ('pkg-config', '0.29.2'),
+]
+
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+
+# Disable deprecated "sockets" provider
+configopts = "--disable-sockets"
+
+sanity_check_paths = {
+    'files': ['bin/fi_info', 'bin/fi_pingpong', 'bin/fi_strerror'] +
+             ['lib/libfabric.%s' % x for x in ['a', SHLIB_EXT]],
+    'dirs': ['include/rdma', 'lib/pkgconfig', 'share']
+}
+
+sanity_check_commands = ['fi_info']
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020a.eb
@@ -16,7 +16,6 @@ dependencies = [
     ('libevent', '2.1.11'),
     ('UCX', '1.8.0', '-CUDA-11.0.2'),
     ('libfabric', '1.11.0'),
-    ('PMIx', '3.1.5'),
 ]
 
 # disable MPI1 compatibility for now, see what breaks...

--- a/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020a.eb
+++ b/easybuild/easyconfigs/o/OpenMPI/OpenMPI-4.0.5-gcccuda-2020a.eb
@@ -1,0 +1,28 @@
+name = 'OpenMPI'
+version = '4.0.5'
+
+homepage = 'https://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-3 implementation."""
+
+toolchain = {'name': 'gcccuda', 'version': '2020a'}
+
+source_urls = ['https://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['572e777441fd47d7f06f1b8a166e7f44b8ea01b8b2e79d1e299d509725d1bd05']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('hwloc', '2.2.0'),
+    ('libevent', '2.1.11'),
+    ('UCX', '1.8.0', '-CUDA-11.0.2'),
+    ('libfabric', '1.11.0'),
+    ('PMIx', '3.1.5'),
+]
+
+# disable MPI1 compatibility for now, see what breaks...
+# configopts = '--enable-mpi1-compatibility '
+
+# to enable SLURM integration (site-specific)
+# configopts += '--with-slurm --with-pmi=/usr/include/slurm --with-pmi-libdir=/usr'
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.1.0-gompic-2020a.eb
+++ b/easybuild/easyconfigs/s/ScaLAPACK/ScaLAPACK-2.1.0-gompic-2020a.eb
@@ -1,0 +1,17 @@
+name = 'ScaLAPACK'
+version = '2.1.0'
+
+homepage = 'https://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompic', 'version': '2020a'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = [SOURCELOWER_TGZ]
+checksums = ['61d9216cf81d246944720cfce96255878a3f85dec13b9351f1fa0fd6768220a6']
+
+dependencies = [('OpenBLAS', '0.3.9')]
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/u/UCX/UCX-1.8.0-GCCcore-9.3.0-CUDA-11.0.2.eb
+++ b/easybuild/easyconfigs/u/UCX/UCX-1.8.0-GCCcore-9.3.0-CUDA-11.0.2.eb
@@ -1,0 +1,63 @@
+# Note:
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.8.0'
+local_cudaversion = '11.0.2'
+versionsuffix = '-CUDA-%s' % local_cudaversion
+
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.7.0_binutils_2.34_api_fix.patch',
+    'UCX-1.8.0_fix-undefined-symbol.patch',
+]
+checksums = [
+    'e400f7aa5354971c8f5ac6b881dc2846143851df868088c37d432c076445628d',  # ucx-1.8.0.tar.gz
+    'c09ebe4d734d520ae23f56d95ba0b91e464a42ccbaf435675424515ebd3fa3a9',  # UCX-1.7.0_binutils_2.34_api_fix.patch
+    'eb757242ab3eecd8a851f329cb4baf3c64d46788ab61675f29ab4cc6a0274a45',  # UCX-1.8.0_fix-undefined-symbol.patch
+]
+
+builddependencies = [
+    ('binutils', '2.34'),
+    ('Autotools', '20180311'),
+    ('pkg-config', '0.29.2'),
+]
+
+osdependencies = [OS_PKG_OPENSSL_DEV]
+
+dependencies = [
+    ('numactl', '2.0.13'),
+    ('CUDAcore', local_cudaversion, '', True),
+    ('GDRCopy', '2.1', versionsuffix),
+]
+
+# CUDA_CFLAGS set by EB toolchain but also used differently in UCX makefiles
+# unset LIBS from EB toolchain to avoid unconditional linking to libcudart:
+# it only needs to be linked by the CUDA run-time plugins
+preconfigopts = 'autoreconf && unset CUDA_CFLAGS && unset LIBS && '
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --disable-doxygen-doc '
+configopts += '--with-cuda=$EBROOTCUDACORE --with-gdrcopy=$EBROOTGDRCOPY '
+
+prebuildopts = 'unset CUDA_CFLAGS && unset LIBS && '
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -634,7 +634,7 @@ class EasyConfigTest(TestCase):
         whitelist = ['BuildEnv', 'CrayToolchain', 'GoPackage', 'ModuleRC', 'PythonBundle', 'PythonPackage',
                      'Toolchain']
         # Autotools & (recent) GCC are just bundles (Autotools: Autoconf+Automake+libtool, GCC: GCCcore+binutils)
-        bundles_whitelist = ['Autotools', 'GCC']
+        bundles_whitelist = ['Autotools', 'GCC', 'CUDA']
         # The BEAR-* modules are just meta modules to simplify module loading in the BlueBEAR Portal
         bundles_whitelist.extend(['BEAR-R-bio', 'BEAR-R-geo', 'BEAR-Python-DataScience', 'BEAR-Python-Sciences', 
                                   'BEAR-Python-MSc-Bioinformatics'])


### PR DESCRIPTION
From upstream, but changed to use OpenMPI 4.0.5 to match what we are using on EL8. Also, not on EL7 as we do not have a new enough NVidia driver installed.

`fosscuda-2020a.eb`
* [x] Assigned to reviewer
* [ ] merge https://github.com/bear-rsg/easybuild-easyblocks/pull/47
* [ ] EL8-haswell
* [ ] EL8-power9
