### PR TITLE
osu mpi benchmarks

### DIFF
--- a/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.6.3-gompi-2020a.eb
+++ b/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.6.3-gompi-2020a.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'OSU-Micro-Benchmarks'
+version = '5.6.3'
+
+homepage = 'https://mvapich.cse.ohio-state.edu/benchmarks/'
+description = """OSU Micro-Benchmarks"""
+
+toolchain = {'name': 'gompi', 'version': '2020a'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c5eaa8c5b086bde8514fa4cac345d66b397e02283bc06e44cb6402268a60aeb8']
+
+configopts = 'CC="$MPICC" CXX="$MPICC"'
+
+local_benchmark_dirs = ['libexec/osu-micro-benchmarks/mpi/%s' % x for x in ['collective', 'one-sided', 'pt2pt']]
+modextrapaths = {'PATH': local_benchmark_dirs}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': local_benchmark_dirs,
+}
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.6.3-iimpi-2020a.eb
+++ b/easybuild/easyconfigs/o/OSU-Micro-Benchmarks/OSU-Micro-Benchmarks-5.6.3-iimpi-2020a.eb
@@ -1,0 +1,25 @@
+easyblock = 'ConfigureMake'
+
+name = 'OSU-Micro-Benchmarks'
+version = '5.6.3'
+
+homepage = 'https://mvapich.cse.ohio-state.edu/benchmarks/'
+description = """OSU Micro-Benchmarks"""
+
+toolchain = {'name': 'iimpi', 'version': '2020a'}
+
+source_urls = ['http://mvapich.cse.ohio-state.edu/download/mvapich/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['c5eaa8c5b086bde8514fa4cac345d66b397e02283bc06e44cb6402268a60aeb8']
+
+configopts = 'CC="$MPICC" CXX="$MPICC"'
+
+local_benchmark_dirs = ['libexec/osu-micro-benchmarks/mpi/%s' % x for x in ['collective', 'one-sided', 'pt2pt']]
+modextrapaths = {'PATH': local_benchmark_dirs}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': local_benchmark_dirs,
+}
+
+moduleclass = 'perf'


### PR DESCRIPTION
For me / ReFrame

As we do not have Intel/2020a on EL7 at the moment, I suggest skipping that.

`OSU-Micro-Benchmarks-5.6.3-gompi-2020a.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7-power9
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] EL8-power9

`OSU-Micro-Benchmarks-5.6.3-iimpi-2020a.eb`
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Already in repo: `HPL-2.3-intel-2020a.eb`
* [ ] EL8-cascadelake
* [ ] EL8-haswell