### PR TITLE
impi fix

### DIFF
--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2020.1.217.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2020.1.217.eb
@@ -31,7 +31,7 @@ modextravars = {
 
     # set this if mpirun gives you a floating point exception (SIGFPE), see
     # https://software.intel.com/en-us/forums/intel-clusters-and-hpc-technology/topic/852307
-    # 'I_MPI_HYDRA_TOPOLIB': 'ipl',
+    'I_MPI_HYDRA_TOPOLIB': 'ipl',
 }
 
 # may be needed if you enable I_MPI_PMI_LIBRARY above


### PR DESCRIPTION
Fixing https://github.com/bear-rsg/easybuild-easyconfigs/pull/393#issuecomment-726881677

`OSU-Micro-Benchmarks-5.6.3-iimpi-2020a.eb`
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Already in repo: `HPL-2.3-intel-2020a.eb`
* [ ] EL8-cascadelake
* [ ] EL8-haswell