### PR TITLE
Clang

### DIFF
--- a/easybuild/easyconfigs/c/Clang/Clang-9.0.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/c/Clang/Clang-9.0.1-GCCcore-8.3.0.eb
@@ -33,7 +33,10 @@ sources = [
     'libcxx-%(version)s.src.tar.xz',
     'libcxxabi-%(version)s.src.tar.xz',
 ]
-patches = ['libcxx-%(version)s-ppc64le.patch']
+patches = [
+    'libcxx-%(version)s-ppc64le.patch',
+    '%(name)s-%(version)s_glibc.patch',
+]
 checksums = [
     '00a1ee1f389f81e9979f3a640a01c431b3021de0d42278f6508391a2f0b81c9a',  # llvm-9.0.1.src.tar.xz
     '5778512b2e065c204010f88777d44b95250671103e434f9dc7363ab2e3804253',  # clang-9.0.1.src.tar.xz
@@ -44,11 +47,13 @@ checksums = [
     '0981ff11b862f4f179a13576ab0a2f5530f46bd3b6b4a90f568ccc6a62914b34',  # libcxx-9.0.1.src.tar.xz
     'e8f978aa4cfae2d7a0b4d89275637078557cca74b35c31b7283d4786948a8aac',  # libcxxabi-9.0.1.src.tar.xz
     '6a39230b9e2b2c61fb5f67ac752d256437ccc56a6a517d7b6d53417d198fdb1f',  # libcxx-9.0.1-ppc64le.patch
+    '7337c0744b1b0d036892aee18e6c30620b14ed2186485bf45123732b97159e32',  # Clang-9.0.1_glibc.patch
 ]
 
 dependencies = [
     # since Clang is a compiler, binutils is a runtime dependency too
     ('binutils', '2.32'),
+    ('ncurses', '6.1'),
     ('GMP', '6.1.2'),
 ]
 

--- a/easybuild/easyconfigs/c/Clang/Clang-9.0.1_glibc.patch
+++ b/easybuild/easyconfigs/c/Clang/Clang-9.0.1_glibc.patch
@@ -1,0 +1,48 @@
+diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.cc b/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+index b7fa6e8..abdf794 100644
+--- a/projects/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/projects/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -1126,8 +1126,9 @@ CHECK_SIZE_AND_OFFSET(ipc_perm, uid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, gid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cuid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
+-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
+-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
++#if !SANITIZER_LINUX || __GLIBC_PREREQ (2, 31)
++/* glibc 2.30 and earlier provided 16-bit mode field instead of 32-bit
++   on many architectures.  */
+ CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
+ #endif
+ 
+diff --git a/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+index f1a4fd7..029a209 100644
+--- a/projects/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/projects/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -203,26 +203,13 @@ namespace __sanitizer {
+     u64 __unused1;
+     u64 __unused2;
+ #elif defined(__sparc__)
+-#if defined(__arch64__)
+     unsigned mode;
+-    unsigned short __pad1;
+-#else
+-    unsigned short __pad1;
+-    unsigned short mode;
+     unsigned short __pad2;
+-#endif
+     unsigned short __seq;
+     unsigned long long __unused1;
+     unsigned long long __unused2;
+-#elif defined(__mips__) || defined(__aarch64__) || defined(__s390x__)
+-    unsigned int mode;
+-    unsigned short __seq;
+-    unsigned short __pad1;
+-    unsigned long __unused1;
+-    unsigned long __unused2;
+ #else
+-    unsigned short mode;
+-    unsigned short __pad1;
++    unsigned int mode;
+     unsigned short __seq;
+     unsigned short __pad2;
+ #if defined(__x86_64__) && !defined(_LP64)


### PR DESCRIPTION
patch from https://bugs.gentoo.org/708430

Fixing Clang allows the other two to build.

`Clang-9.0.1-GCCcore-8.3.0.eb Longshot-0.4.1-GCCcore-8.3.0.eb pocl-1.4-GCC-8.3.0.eb`
* [x] Assigned to reviewer
* [ ] Ubuntu20 VM