### PR TITLE
switch impi version on EL8

### DIFF
--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019b.eb
@@ -4,7 +4,7 @@ easyblock = 'Toolchain'
 name = 'iimpi'
 version = '2019b'
 
-homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+homepage = 'https://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
 description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2019b.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2019b.eb
@@ -12,7 +12,7 @@ toolchain = SYSTEM
 local_compver = '2019.5.281'
 dependencies = [
     ('iccifort', local_compver),
-    ('impi', '2018.5.288', '', ('iccifort', local_compver)),
+    ('impi', '2019.7.217', '', ('iccifort', local_compver)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/iimpic/iimpic-2019b.eb
+++ b/easybuild/easyconfigs/i/iimpic/iimpic-2019b.eb
@@ -14,7 +14,7 @@ local_compver = '2019.5.281'
 dependencies = [
     ('iccifort', local_compver),
     ('CUDA', '10.1.243', '', ('iccifort', local_compver)),
-    ('impi', '2018.5.288', '', ('iccifortcuda', version)),
+    ('impi', '2019.7.217', '', ('iccifortcuda', version)),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2019.5.281.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2019.5.281.eb
@@ -3,12 +3,12 @@
 name = 'impi'
 version = '2019.7.217'
 
-homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+homepage = 'https://software.intel.com/en-us/intel-mpi-library/'
 description = "Intel MPI Library, compatible with MPICH ABI"
 
 toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
 
-source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
+source_urls = ['https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
 sources = ['l_mpi_%(version)s.tgz']
 checksums = ['90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07']
 

--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2019.5.281.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifort-2019.5.281.eb
@@ -1,0 +1,37 @@
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild
+
+name = 'impi'
+version = '2019.7.217'
+
+homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+description = "Intel MPI Library, compatible with MPICH ABI"
+
+toolchain = {'name': 'iccifort', 'version': '2019.5.281'}
+
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
+sources = ['l_mpi_%(version)s.tgz']
+checksums = ['90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07']
+
+dependencies = [
+    # needed by libfabric provider MLX introduced in Intel MPI v2019.6,
+    # https://software.intel.com/en-us/articles/improve-performance-and-stability-with-intel-mpi-library-on-infiniband
+    ('UCX', '1.6.1'),
+]
+
+dontcreateinstalldir = 'True'
+
+components = ['intel-mpi', 'intel-psxe', 'intel-imb']
+
+# set up all the mpi commands to default to intel compilers
+# set_mpi_wrappers_all = 'True'
+
+modextravars = {
+    # to enable SLURM integration with srun (site-specific)
+    # 'I_MPI_PMI_LIBRARY': 'libpmi2.so',
+
+    # set this if mpirun gives you a floating point exception (SIGFPE), see
+    # https://software.intel.com/en-us/forums/intel-clusters-and-hpc-technology/topic/852307
+    'I_MPI_HYDRA_TOPOLIB': 'ipl',
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifortcuda-2019b.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifortcuda-2019b.eb
@@ -1,0 +1,37 @@
+# This is an easyconfig file for EasyBuild, see http://easybuilders.github.io/easybuild
+
+name = 'impi'
+version = '2019.7.217'
+
+homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+description = "Intel MPI Library, compatible with MPICH ABI"
+
+toolchain = {'name': 'iccifortcuda', 'version': '2019b'}
+
+source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
+sources = ['l_mpi_%(version)s.tgz']
+checksums = ['90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07']
+
+dependencies = [
+    # needed by libfabric provider MLX introduced in Intel MPI v2019.6,
+    # https://software.intel.com/en-us/articles/improve-performance-and-stability-with-intel-mpi-library-on-infiniband
+    ('UCX', '1.6.1'),
+]
+
+dontcreateinstalldir = 'True'
+
+components = ['intel-mpi', 'intel-psxe', 'intel-imb']
+
+# set up all the mpi commands to default to intel compilers
+# set_mpi_wrappers_all = 'True'
+
+modextravars = {
+    # to enable SLURM integration with srun (site-specific)
+    # 'I_MPI_PMI_LIBRARY': 'libpmi2.so',
+
+    # set this if mpirun gives you a floating point exception (SIGFPE), see
+    # https://software.intel.com/en-us/forums/intel-clusters-and-hpc-technology/topic/852307
+    'I_MPI_HYDRA_TOPOLIB': 'ipl',
+}
+
+moduleclass = 'mpi'

--- a/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifortcuda-2019b.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2019.7.217-iccifortcuda-2019b.eb
@@ -3,12 +3,12 @@
 name = 'impi'
 version = '2019.7.217'
 
-homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
+homepage = 'https://software.intel.com/en-us/intel-mpi-library/'
 description = "Intel MPI Library, compatible with MPICH ABI"
 
 toolchain = {'name': 'iccifortcuda', 'version': '2019b'}
 
-source_urls = ['http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
+source_urls = ['https://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15614/']
 sources = ['l_mpi_%(version)s.tgz']
 checksums = ['90383b0023f84ac003a55d8bb29dbcf0c639f43a25a2d8d8698a16e770ac9c07']
 

--- a/easybuild/easyconfigs/i/intel/intel-2019b.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2019b.eb
@@ -15,7 +15,7 @@ dependencies = [
     ('GCCcore', local_gccver),
     ('binutils', '2.32', '-GCCcore-%s' % local_gccver),
     ('iccifort', local_compver),
-    ('impi', '2018.5.288', '', ('iccifort', local_compver)),
+    ('impi', '2019.7.217', '', ('iccifort', local_compver)),
     ('imkl', '2019.5.281', '', ('iimpi', version)),
 ]
 

--- a/easybuild/easyconfigs/i/intelcuda/intelcuda-2019b.eb
+++ b/easybuild/easyconfigs/i/intelcuda/intelcuda-2019b.eb
@@ -13,7 +13,7 @@ local_compver = '2019.5.281'
 dependencies = [
     ('iccifort', local_compver),
     ('CUDA', '10.1.243', '', ('iccifort', local_compver)),
-    ('impi', '2018.5.288', '', ('iccifortcuda', version)),
+    ('impi', '2019.7.217', '', ('iccifortcuda', version)),
     ('imkl', '2019.5.281', '', ('iimpic', version)),
 ]
 


### PR DESCRIPTION
For EL8 the impi goes boom - so replace it with one that works.

* [x] Assigned to reviewer

Rebuild: `iimpi-2019b.eb intel-2019b.eb`
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM

Rebuild: `iimpic-2019b.eb intelcuda-2019b.eb`
* [ ] EL8-haswell