### PR TITLE
deepTools 3.5.0 and deps

### DIFF
--- a/easybuild/easyconfigs/d/deepTools/deepTools-3.5.0-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/d/deepTools/deepTools-3.5.0-foss-2020a-Python-3.8.2.eb
@@ -1,0 +1,52 @@
+easyblock = 'PythonBundle'
+
+name = 'deepTools'
+version = '3.5.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://deeptools.readthedocs.io/'
+description = """deepTools is a suite of python tools particularly developed for the efficient analysis of
+ high-throughput sequencing data, such as ChIP-seq, RNA-seq or MNase-seq."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('Pysam', '0.16.0.1'),
+    ('matplotlib', '3.2.1', versionsuffix),
+    ('plotly.py', '4.8.1'),
+]
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+use_pip = True
+
+exts_list = [
+    ('py2bit', '0.3.0', {
+        'checksums': ['450555c40cba66957ac8c9a4b6afb625fb34c4bb41638de78c87661ff8b682ef'],
+    }),
+    ('pyBigWig', '0.3.17', {
+        'modulename': 'pyBigWig',
+        'checksums': ['41f64f802689ed72e15296a21a4b7abd3904780b2e4f8146fd29098fc836fd94'],
+    }),
+    ('deeptoolsintervals', '0.1.9', {
+        'checksums': ['7d94c36fd2b6f10d8b99e536d2672e8228971f1fc810497d33527bba2c40d4f6'],
+    }),
+    ('numpydoc', '1.1.0', {
+        'checksums': ['c36fd6cb7ffdc9b4e165a43f67bf6271a7b024d0bb6b00ac468c9e2bfc76448e'],
+    }),
+    (name, version, {
+        'checksums': ['1a14a29e60be13eac11bd204dab9aef73cd72fe56a94c587333f21087584c0d8'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': ['bin/bamCompare', 'bin/bamCoverage', 'bin/bamPEFragmentSize', 'bin/computeGCBias', 'bin/computeMatrix',
+              'bin/correctGCBias', 'bin/multiBamSummary', 'bin/plotCorrelation', 'bin/plotCoverage',
+              'bin/plotHeatmap', 'bin/plotProfile'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_pip_check = True
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/Pysam/Pysam-0.16.0.1-GCC-9.3.0.eb
+++ b/easybuild/easyconfigs/p/Pysam/Pysam-0.16.0.1-GCC-9.3.0.eb
@@ -1,0 +1,45 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics
+# 0.9.1.4:
+# Modified by: Adam Huffman
+# The Francis Crick Institute
+# Modified by: Erich Birngruber
+# Gregor Mendel Institute
+# Modified by: Pavel Grochal
+# INUITS
+
+easyblock = 'PythonPackage'
+
+name = 'Pysam'
+version = '0.16.0.1'
+
+homepage = 'https://github.com/pysam-developers/pysam'
+description = """Pysam is a python module for reading and manipulating Samfiles.
+ It's a lightweight wrapper of the samtools C-API. Pysam also includes an interface for tabix."""
+
+toolchain = {'name': 'GCC', 'version': '9.3.0'}
+
+source_urls = ['https://github.com/pysam-developers/pysam/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['a61e98e299fa93ba121aab521081282b61bc978bb9052d33b26b38f8fe15573e']
+
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
+
+dependencies = [
+    ('ncurses', '6.2'),
+    ('cURL', '7.69.1'),
+    ('XZ', '5.2.5'),
+]
+
+download_dep_fail = True
+use_pip = True
+sanity_pip_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/p/plotly.py/plotly.py-4.8.1-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/p/plotly.py/plotly.py-4.8.1-GCCcore-9.3.0.eb
@@ -1,0 +1,32 @@
+easyblock = 'PythonBundle'
+
+name = 'plotly.py'
+version = '4.8.1'
+
+homepage = 'https://plot.ly/python'
+description = "An open-source, interactive graphing library for Python"
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+multi_deps = {'Python': ['3.8.2', '2.7.18']}
+
+use_pip = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('retrying', '1.3.3', {
+        'checksums': ['08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b'],
+    }),
+    ('plotly', version, {
+        'checksums': ['d3fea527fe3dfdd55d7334318f107b05a8407474a0fffe6cd4726c9b99e624f1'],
+    }),
+]
+
+sanity_pip_check = True
+
+builddependencies = [
+    ('binutils', '2.34'),
+]
+
+moduleclass = 'vis'


### PR DESCRIPTION
For INC1093318

`deepTools-3.5.0-foss-2020a-Python-3.8.2.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM

deps are from usptream, deepTools is just version/toolchain bumps