### PR TITLE
Fix tombo for rpy2 v3

### DIFF
--- a/easybuild/easyconfigs/t/tombo/tombo-1.5.1-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/t/tombo/tombo-1.5.1-foss-2019b-Python-3.7.4.eb
@@ -13,7 +13,11 @@ description = """Tombo is a suite of tools primarily for the identification of m
 
 source_urls = ['https://github.com/nanoporetech/%(name)s/archive/']
 sources = ['%(version)s.tar.gz']
-checksums = ['f5f7ce37baee40b851ea867c2b835e6eae324ef90bdeb23fb931fde3272769a0']
+patches = ['%(name)s-%(version)s_rpy2-v3.patch']
+checksums = [
+    'f5f7ce37baee40b851ea867c2b835e6eae324ef90bdeb23fb931fde3272769a0',  # 1.5.1.tar.gz
+    'ff5c5d2725d9224a91d04499fd9b20730531cddd5f97b711ba46c79612eb486a',  # tombo-1.5.1_rpy2-v3.patch
+]
 
 dependencies = [
     ('Python', '3.7.4'),

--- a/easybuild/easyconfigs/t/tombo/tombo-1.5.1_rpy2-v3.patch
+++ b/easybuild/easyconfigs/t/tombo/tombo-1.5.1_rpy2-v3.patch
@@ -1,0 +1,13 @@
+Suport rpy2 v3 by initialising the DataFrame with a dict
+https://github.com/nanoporetech/tombo/issues/208
+--- tombo/_plot_commands.py.orig	2020-12-16 14:28:04.891944000 +0000
++++ tombo/_plot_commands.py	2020-12-16 14:28:14.682304346 +0000
+@@ -44,7 +44,7 @@
+ try:
+     from rpy2 import robjects as r
+     from rpy2.robjects.packages import importr
+-    _R_DF = r.DataFrame(())
++    _R_DF = r.DataFrame({})
+ except:
+     # pass here and print detailed error when main functions are actually called
+     # in  to give specific error message

--- a/easybuild/easyconfigs/t/tombo/tombo-7473afe-foss-2019b-Python-3.7.4-cowplot.eb
+++ b/easybuild/easyconfigs/t/tombo/tombo-7473afe-foss-2019b-Python-3.7.4-cowplot.eb
@@ -14,10 +14,14 @@ description = """Tombo is a suite of tools primarily for the identification of m
 
 source_urls = ['https://github.com/nanoporetech/%(name)s/archive/']
 sources = ['%(version)s.tar.gz']
-patches = ['tombo_cowplot.patch']
+patches = [
+    'tombo_cowplot.patch',
+    '%(name)s-1.5.1_rpy2-v3.patch',
+]
 checksums = [
     '23bf17fca849b1a87e3bbc9017e726847cc2cd6e6060d1d09cba84cbdc7e3bc6',  # 7473afe.tar.gz
     '66ff9893470052f948cd3193572bf9a7fc622c96879902433e3e383575695c12',  # tombo_cowplot.patch
+    'ff5c5d2725d9224a91d04499fd9b20730531cddd5f97b711ba46c79612eb486a',  # tombo-1.5.1_rpy2-v3.patch
 ]
 
 dependencies = [


### PR DESCRIPTION
For INC1096693

Rebuild: `tombo-1.5.1-foss-2019b-Python-3.7.4.eb tombo-7473afe-foss-2019b-Python-3.7.4-cowplot.eb`
* [x] Assigned to reviewer
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] Ubuntu16 VM
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM
