### PR TITLE
DualSPHysics

### DIFF
--- a/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-foss-2020a-Java-11.eb
+++ b/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-foss-2020a-Java-11.eb
@@ -40,7 +40,8 @@ modextrapaths = {
 }
 
 sanity_check_paths = {
-    'files': ['%%(name)s-%%(version)s/bin/linux/DualSPHysics5.0%s' % x for x in ['CPU_linux64', '_NNewtonianCPU_linux64']],
+    'files': ['%%(name)s-%%(version)s/bin/linux/DualSPHysics5.0%s' % x for x in ['CPU_linux64',
+              '_NNewtonianCPU_linux64']],
     'dirs': ['%(name)s-%(version)s/src'],
 }
 

--- a/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-foss-2020a-Java-11.eb
+++ b/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-foss-2020a-Java-11.eb
@@ -1,0 +1,47 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'DualSPHysics'
+version = '5.0.164'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = "https://dual.sphysics.org"
+description = """DualSPHysics is based on the Smoothed Particle Hydrodynamics model named SPHysics (www.sphysics.org).
+ The code is developed (GNU Lesser General Public License) to study free-surface flow phenomena where Eulerian methods
+ can be difficult to apply. DualSPHysics is a set of C++, CUDA and Java codes designed to deal with real-life
+ engineering problems."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+source_urls = ['https://github.com/DualSPHysics/DualSPHysics/archive']
+sources = ['v%(version)s.tar.gz']
+patches = ['%(name)s_%(version)s_makefiles.patch']
+checksums = [
+    '2c060fe3d26897dcf90a0586ec1a05efdc44e51ce657535702e5809cebe06e8d',  # v5.0.164.tar.gz
+    '89c7073cb4440d8f026b139bfdacf1d207585d11a1f8687bc1539a042c37d647',  # DualSPHysics_5.0.164_makefiles.patch
+]
+
+dependencies = [
+    ('Java', '11', '', True),
+]
+
+skipsteps = ['configure']
+
+buildininstalldir = True
+build_cmd = 'cd src/source && make -f Makefile_cpu && '
+build_cmd += 'cd ../../src_mphase/DSPH_v5.0_NNewtonian/source && make -f Makefile_cpu'
+
+install_cmd = 'chmod 755 bin/linux/*'
+
+modextrapaths = {
+    'PATH': '%(name)s-%(version)s/bin/linux',
+    'LD_LIBRARY_PATH': ['%%(name)s-%%(version)s/%s' % x for x in ['src/lib/linux_gcc',
+                        'src_mphase/DSPH_v5.0_NNewtonian/lib/linux_gcc']],
+}
+
+sanity_check_paths = {
+    'files': ['%%(name)s-%%(version)s/bin/linux/DualSPHysics5.0%s' % x for x in ['CPU_linux64', '_NNewtonianCPU_linux64']],
+    'dirs': ['%(name)s-%(version)s/src'],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-fosscuda-2020a-Java-11.eb
+++ b/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics-5.0.164-fosscuda-2020a-Java-11.eb
@@ -1,0 +1,47 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'ConfigureMake'
+
+name = 'DualSPHysics'
+version = '5.0.164'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = "https://dual.sphysics.org"
+description = """DualSPHysics is based on the Smoothed Particle Hydrodynamics model named SPHysics (www.sphysics.org).
+ The code is developed (GNU Lesser General Public License) to study free-surface flow phenomena where Eulerian methods
+ can be difficult to apply. DualSPHysics is a set of C++, CUDA and Java codes designed to deal with real-life
+ engineering problems."""
+
+toolchain = {'name': 'fosscuda', 'version': '2020a'}
+
+source_urls = ['https://github.com/DualSPHysics/DualSPHysics/archive']
+sources = ['v%(version)s.tar.gz']
+patches = ['%(name)s_%(version)s_makefiles.patch']
+checksums = [
+    '2c060fe3d26897dcf90a0586ec1a05efdc44e51ce657535702e5809cebe06e8d',  # v5.0.164.tar.gz
+    '89c7073cb4440d8f026b139bfdacf1d207585d11a1f8687bc1539a042c37d647',  # DualSPHysics_5.0.164_makefiles.patch
+]
+
+dependencies = [
+    ('Java', '11', '', True),
+]
+
+skipsteps = ['configure']
+
+buildininstalldir = True
+build_cmd = 'cd src/source && make && '
+build_cmd += 'cd ../../src_mphase/DSPH_v5.0_NNewtonian/source && make'
+
+install_cmd = 'chmod 755 bin/linux/*'
+
+modextrapaths = {
+    'PATH': '%(name)s-%(version)s/bin/linux',
+    'LD_LIBRARY_PATH': ['%%(name)s-%%(version)s/%s' % x for x in ['src/lib/linux_gcc',
+                        'src_mphase/DSPH_v5.0_NNewtonian/lib/linux_gcc']],
+}
+
+sanity_check_paths = {
+    'files': ['%%(name)s-%%(version)s/bin/linux/DualSPHysics5.0%s' % x for x in ['_linux64', '_NNewtonian_linux64']],
+    'dirs': ['%(name)s-%(version)s/src'],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics_5.0.164_makefiles.patch
+++ b/easybuild/easyconfigs/d/DualSPHysics/DualSPHysics_5.0.164_makefiles.patch
@@ -1,0 +1,175 @@
+Only in DualSPHysics-5.0.164: DualSPHysics_5.0.164_Nvidia_11.patch
+diff -ru DualSPHysics-5.0.164.orig/src/source/Makefile DualSPHysics-5.0.164/src/source/Makefile
+--- DualSPHysics-5.0.164.orig/src/source/Makefile	2021-01-19 16:34:08.963407000 +0000
++++ DualSPHysics-5.0.164/src/source/Makefile	2021-01-20 18:43:56.545595604 +0000
+@@ -1,10 +1,10 @@
+ #DualSPHysics GPU/CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -27,7 +27,9 @@
+     CCFLAGS+= -ffast-math
+   endif
+   ifeq ($(USE_NATIVE_CPU_OPTIMIZATIONS), YES)
+-    CCFLAGS+= -march=native
++	ifeq ($(shell uname -p), x86_64)
++		CCFLAGS+= -march=native
++	endif
+   endif
+ endif
+ CC=g++
+@@ -61,7 +63,7 @@
+ endif
+ 
+ #=============== CUDA selection ===============
+-CUDAVER=92
++CUDAVER=110
+ 
+ #=============== CUDA toolkit directory (make appropriate for local CUDA installation) ===============
+ ifeq ($(CUDAVER),00)
+@@ -76,6 +78,9 @@
+ ifeq ($(CUDAVER),92)
+   DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.2
+ endif
++ifeq ($(CUDAVER),110)
++  DIRTOOLKIT=$(EBROOTCUDA)
++endif
+ 
+ #=============== Select GPU architectures ===============
+ ifeq ($(CUDAVER),00)
+@@ -107,6 +112,13 @@
+   GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+   GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+ endif
++ifeq ($(CUDAVER),110)
++  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_75,code=\"sm_75,compute_75\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_80,code=\"sm_80,compute_80\"
++endif
+ 
+ 
+ #=============== Files to compile ===============
+diff -ru DualSPHysics-5.0.164.orig/src/source/Makefile_cpu DualSPHysics-5.0.164/src/source/Makefile_cpu
+--- DualSPHysics-5.0.164.orig/src/source/Makefile_cpu	2021-01-19 16:34:09.045918000 +0000
++++ DualSPHysics-5.0.164/src/source/Makefile_cpu	2021-01-20 18:44:22.191177000 +0000
+@@ -1,10 +1,10 @@
+ #DualSPHysics CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -27,7 +27,9 @@
+     CCFLAGS+= -ffast-math
+   endif
+   ifeq ($(USE_NATIVE_CPU_OPTIMIZATIONS), YES)
+-    CCFLAGS+= -march=native
++    ifeq ($(shell uname -p), x86_64)
++		CCFLAGS+= -march=native
++	endif
+   endif
+ endif
+ CC=g++
+diff -ru DualSPHysics-5.0.164.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile DualSPHysics-5.0.164/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile
+--- DualSPHysics-5.0.164.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile	2021-01-19 16:34:07.356044000 +0000
++++ DualSPHysics-5.0.164/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile	2021-01-20 18:44:55.846815377 +0000
+@@ -1,10 +1,10 @@
+ #DualSPHysics NNewtonian GPU/CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -27,7 +27,9 @@
+     CCFLAGS+= -ffast-math
+   endif
+   ifeq ($(USE_NATIVE_CPU_OPTIMIZATIONS), YES)
+-    CCFLAGS+= -march=native
++	ifeq ($(shell uname -p), x86_64)
++    	CCFLAGS+= -march=native
++	endif
+   endif
+ endif
+ CC=g++
+@@ -61,7 +63,7 @@
+ endif
+ 
+ #=============== CUDA selection ===============
+-CUDAVER=92
++CUDAVER=110
+ 
+ #=============== CUDA toolkit directory (make appropriate for local CUDA installation) ===============
+ ifeq ($(CUDAVER),00)
+@@ -76,6 +78,9 @@
+ ifeq ($(CUDAVER),92)
+   DIRTOOLKIT=/exports/opt/NVIDIA/cuda-9.2
+ endif
++ifeq ($(CUDAVER),110)
++  DIRTOOLKIT=$(EBROOTCUDA)
++endif
+ 
+ #=============== Select GPU architectures ===============
+ ifeq ($(CUDAVER),00)
+@@ -107,6 +112,13 @@
+   GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+   GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
+ endif
++ifeq ($(CUDAVER),110)
++  GENCODE:=$(GENCODE) -gencode=arch=compute_52,code=\"sm_52,compute_52\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_61,code=\"sm_61,compute_61\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_70,code=\"sm_70,compute_70\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_75,code=\"sm_75,compute_75\"
++  GENCODE:=$(GENCODE) -gencode=arch=compute_80,code=\"sm_80,compute_80\"
++endif
+ 
+ 
+ #=============== Files to compile ===============
+diff -ru DualSPHysics-5.0.164.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu DualSPHysics-5.0.164/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu
+--- DualSPHysics-5.0.164.orig/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu	2021-01-19 16:34:07.439185000 +0000
++++ DualSPHysics-5.0.164/src_mphase/DSPH_v5.0_NNewtonian/source/Makefile_cpu	2021-01-20 18:45:39.214486000 +0000
+@@ -1,10 +1,10 @@
+ #DualSPHysics NNewtonian CPU v5.0.164 21-11-2020
+ 
+ #=============== Compilation Options (YES/NO) ===============
+-USE_GCC5=NO
++USE_GCC5=YES
+ USE_DEBUG=NO
+ USE_FAST_MATH=YES
+-USE_NATIVE_CPU_OPTIMIZATIONS=NO
++USE_NATIVE_CPU_OPTIMIZATIONS=YES
+ COMPILE_VTKLIB=YES
+ COMPILE_NUMEXLIB=YES
+ COMPILE_CHRONO=YES
+@@ -27,7 +27,9 @@
+     CCFLAGS+= -ffast-math
+   endif
+   ifeq ($(USE_NATIVE_CPU_OPTIMIZATIONS), YES)
+-    CCFLAGS+= -march=native
++	ifeq ($(shell uname -p), x86_64)
++    	CCFLAGS+= -march=native
++	endif
+   endif
+ endif
+ CC=g++


### PR DESCRIPTION
For INC1100345.

There were problems installing on power9 (e.g. `ld.gold: warning: skipping incompatible ../lib/linux_gcc/libjvtklib_64.a while searching for jvtklib_64`), so I left it (it was not specifically requested either).

* [x] Assigned to reviewer

`DualSPHysics-5.0.164-foss-2020a-Java-11.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell

`DualSPHysics-5.0.164-fosscuda-2020a-Java-11.eb`
* [ ] EL8-haswell

