### PR TITLE
QE

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7-iomkl-2019b.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7-iomkl-2019b.eb
@@ -1,0 +1,43 @@
+name = 'QuantumESPRESSO'
+version = '6.7'
+
+homepage = 'https://www.quantum-espresso.org'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft).
+"""
+
+toolchain = {'name': 'iomkl', 'version': '2019b'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = [
+    'https://github.com/QEF/q-e/releases/download/qe-%(version)s.0/',
+    'https://github.com/dceresoli/qe-gipaw/archive/',
+    'https://github.com/wannier-developers/wannier90/archive/'
+]
+sources = [
+    'qe-%(version)s-ReleasePack.tgz',
+    # to be uncommented once qe-gipaw-6.7 is released
+    # {'filename': 'qe-gipaw-%(version)s.tar.gz', 'download_filename': '%(version)s.tar.gz'},
+    {'filename': 'wannier90-3.1.0.tar.gz', 'download_filename': 'v3.1.0.tar.gz'},
+]
+checksums = [
+    '8f06ea31ae52ad54e900a2f51afd5c70f78096d9dcf39c86c2b17dccb1ec9c87',  # qe-6.7-ReleasePack.tgz
+    '40651a9832eb93dec20a8360dd535262c261c34e13c41b6755fa6915c936b254',  # wannier90-3.1.0.tar.gz
+]
+
+dependencies = [
+    ('HDF5', '1.10.5'),
+    ('ELPA', '2019.11.001'),
+    ('libxc', '4.3.4'),
+]
+
+# The third party packages should be installed separately and added as
+# dependencies.  The exception is w90, which is force built
+buildopts = 'all gwl xspectra couple epw w90'  # gipaw
+
+# parallel build tends to fail
+parallel = 1
+
+moduleclass = 'chem'


### PR DESCRIPTION
For INC1096952 - `QuantumESPRESSO-6.7-iomkl-2019b.eb` (based off upstream intel version)

`gipaw` is disabled as it is not currently available for QE 6.7.

* [x] Assigned to reviewer
* [ ] https://github.com/bear-rsg/easybuild-easyblocks/pull/61 (is merged but needs to be pulled to live)

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell