### PR TITLE
Qualimap

### DIFF
--- a/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/q/Qualimap/Qualimap-2.2.1-foss-2019b-R-3.6.2.eb
@@ -1,0 +1,33 @@
+easyblock = 'Tarball'
+
+name = 'Qualimap'
+version = '2.2.1'
+versionsuffix = '-R-%(rver)s'
+
+homepage = 'http://qualimap.conesalab.org/'
+description = """Qualimap 2 is a platform-independent application written in Java and R that provides both
+ a Graphical User Inteface (GUI) and a command-line interface to facilitate the quality control of
+ alignment sequencing data and its derivatives like feature counts."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://bitbucket.org/kokonech/qualimap/downloads/']
+sources = ['qualimap_v%(version)s.zip']
+checksums = ['08f1d66e49c83c76c56c4225c53aee44f41e0592c8bdc84b8c4ecd975700e045']
+
+dependencies = [
+    ('Java', '11', '', True),
+    ('R', '3.6.2'),
+    ('R-bundle-Bioconductor', '3.10', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': ['qualimap'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["qualimap --help"]
+
+modextrapaths = {'PATH': ''}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1105008 - `Qualimap-2.2.1-foss-2019b-R-3.6.2.eb`

In 2019b as against an R 3.x - based on upstream version.

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu16 VM
* [ ] Ubuntu20 VM
