### PR TITLE
Enforce sequential IO since NetCDF4/HDF5 is not threadsafe

### DIFF
--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10-iomkl-2020a.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10-iomkl-2020a.eb
@@ -12,7 +12,11 @@ toolchainopts = {'pic': True, 'usempi': True, 'lowopt': True}
 
 source_urls = ['https://code.mpimet.mpg.de/attachments/download/24638/']
 sources = [SOURCELOWER_TAR_GZ]
-checksums = ['cc39c89bbb481d7b3945a06c56a8492047235f46ac363c4f0d980fccdde6677e']
+patches = ['%(name)s-%(version)s_force_lock_io.patch']
+checksums = [
+    'cc39c89bbb481d7b3945a06c56a8492047235f46ac363c4f0d980fccdde6677e',  # cdo-1.9.10.tar.gz
+    'fbad6a7ac984dbf274c0487d7df3dc74216e560a3e328135094842a9886775ba',  # CDO-1.9.10_force_lock_io.patch
+]
 
 dependencies = [
     ('HDF5', '1.10.6'),

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10_force_lock_io.patch
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10_force_lock_io.patch
@@ -1,0 +1,15 @@
+--- src/cdo.cc.orig	2021-02-05 14:00:43.894719902 +0000
++++ src/cdo.cc	2021-02-05 14:04:51.001083436 +0000
+@@ -1335,6 +1335,12 @@
+       return 1;
+     }
+ 
++  if (!Threading::cdoLockIO)
++    {
++      fprintf(stderr, " > BEAR: Enabling '-L Lock IO (sequential access)' as NetCDF4/HDF5 is not thread safe\n");
++      Threading::cdoLockIO = true;
++    }
++
+   return 0;
+ }
+ 


### PR DESCRIPTION
For INC1105445 - `CDO-1.9.10-iomkl-2020a.eb`

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell
