### PR TITLE
Go 1.14.1

### DIFF
--- a/easybuild/easyconfigs/g/Go/Go-1.14.1.eb
+++ b/easybuild/easyconfigs/g/Go/Go-1.14.1.eb
@@ -19,4 +19,5 @@ sanity_check_paths = {
 }
 
 modextravars = {'GOROOT': '%(installdir)s'}
+
 moduleclass = 'compiler'


### PR DESCRIPTION
For INC1106760 - `Go-1.14.1.eb`

Note: Easyconfig already exists.

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] Ubuntu16 VM
* [ ] Ubuntu20 VM
