### PR TITLE
UTMOST

### DIFF
--- a/easybuild/easyconfigs/g/GBJ/GBJ-0.5.0-foss-2019b-R-3.6.2.eb
+++ b/easybuild/easyconfigs/g/GBJ/GBJ-0.5.0-foss-2019b-R-3.6.2.eb
@@ -1,0 +1,45 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'GBJ'
+version = '0.5.0'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=GBJ"
+description = """GBJ offers the Generalized Berk-Jones (GBJ) test for set-based inference in genetic association
+ studies. The GBJ is designed as an alternative to tests such as Berk-Jones (BJ), Higher Criticism (HC), Generalized
+ Higher Criticism (GHC), Minimum p-value (minP), and Sequence Kernel Association Test (SKAT)."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+dependencies = [
+    ('R', '3.6.2'),
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+
+# Order is important!
+exts_list = [
+    (name, version, {
+        'checksums': ['a3e8f4d835aa57b592d3bbbc3c6c551834a0b55a38b3074d617cd32d5af3991f'],
+    }),
+]
+
+modextrapaths = {'R_LIBS': ''}
+
+sanity_check_paths = {
+    'files': ['GBJ/R/GBJ'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/u/UTMOST/UTMOST-88e9d1d-foss-2019b-Python-2.7.16-R-3.6.2.eb
+++ b/easybuild/easyconfigs/u/UTMOST/UTMOST-88e9d1d-foss-2019b-Python-2.7.16-R-3.6.2.eb
@@ -1,0 +1,45 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Binary'
+
+name = 'UTMOST'
+version = '88e9d1d'
+local_pysuffix = '-Python-%(pyver)s'
+local_rsuffix = '-R-%(rver)s'
+versionsuffix = '%s%s' % (local_pysuffix, local_rsuffix)
+
+homepage = "https://github.com/Joker-Jerome/UTMOST"
+description = """UTMOST (Unified Test for MOlecular SignaTures) is a principled method to perform cross-tissue
+ expression imputation and gene-level association analysis."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://github.com/Joker-Jerome/UTMOST/archive']
+sources = ['%(version)s.tar.gz']
+checksums = ['52c76608f8c45b8199ebea9845335379a61e6064a962eba96205daff8f11dfbf']
+
+dependencies = [
+    ('Python', '2.7.16'),
+    ('SciPy-bundle', '2019.10', local_pysuffix),
+    ('R', '3.6.2'),
+    ('rpy2', '2.8.6', local_pysuffix),
+    ('GBJ', '0.5.0', local_rsuffix),
+]
+
+extract_sources = True
+install_cmd = 'chmod 755 *.py && '
+install_cmd += 'chmod 755 test/joint_gbj_break3.py && '
+install_cmd += 'chmod 755 metax/Filtering.py && chmod 755 metax/M0* && '
+install_cmd += 'cp -r * %(installdir)s'
+fix_python_shebang_for = ['*.py', 'metax/Filtering.py', 'test/joint_gbj_break3.py']
+
+modextrapaths = {
+    'PATH': ['', 'test', 'metax'],
+}
+
+sanity_check_paths = {
+    'files': ['joint_GBJ_test.py', 'joint_covariance.py', 'single_tissue_association_test.py',
+              'single_tissue_covariance.py'],
+    'dirs': ['intermediate', 'metax', 'test'],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1104287 - `UTMOST-88e9d1d-foss-2019b-Python-2.7.16-R-3.6.2.eb`

Requires `rpy2 2.8.6` and an old version of `GBJ`, so I put it in 2019b.

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] Ubuntu16 VM
* [ ] Ubuntu20 VM
