### PR TITLE
elastool examples updated

### DIFF
--- a/easybuild/easyconfigs/e/elastool/elastool-7199f7a-intel-2019b-Python-3.7.4-VASP-5.4.4.eb
+++ b/easybuild/easyconfigs/e/elastool/elastool-7199f7a-intel-2019b-Python-3.7.4-VASP-5.4.4.eb
@@ -25,7 +25,11 @@ dependencies = [
 
 source_urls = ['https://github.com/zhongliliu/elastool/archive']
 sources = ['%(version)s.tar.gz']
-checksums = ['83f56b70354c202c53b1322137cdb8c73a3b929582baeaef064f94695dd12635']
+patches = ['elastool_examples.patch']
+checksums = [
+    '83f56b70354c202c53b1322137cdb8c73a3b929582baeaef064f94695dd12635',  # 7199f7a.tar.gz
+    '49367a928f2fd6c0b3381fd01ae309dceea6c75b47560276543f64d91454e6d0',  # elastool_examples.patch
+]
 
 skipsteps = ['configure', 'build']
 

--- a/easybuild/easyconfigs/e/elastool/elastool-7199f7a-iomkl-2019b-Python-3.7.4-VASP-5.4.4.eb
+++ b/easybuild/easyconfigs/e/elastool/elastool-7199f7a-iomkl-2019b-Python-3.7.4-VASP-5.4.4.eb
@@ -26,7 +26,10 @@ dependencies = [
 source_urls = ['https://github.com/zhongliliu/elastool/archive']
 sources = ['%(version)s.tar.gz']
 patches = ['elastool_examples.patch']
-checksums = ['83f56b70354c202c53b1322137cdb8c73a3b929582baeaef064f94695dd12635']
+checksums = [
+    '83f56b70354c202c53b1322137cdb8c73a3b929582baeaef064f94695dd12635',  # 7199f7a.tar.gz
+    '49367a928f2fd6c0b3381fd01ae309dceea6c75b47560276543f64d91454e6d0',  # elastool_examples.patch
+]
 
 skipsteps = ['configure', 'build']
 

--- a/easybuild/easyconfigs/e/elastool/elastool-7199f7a-iomkl-2019b-Python-3.7.4-VASP-5.4.4.eb
+++ b/easybuild/easyconfigs/e/elastool/elastool-7199f7a-iomkl-2019b-Python-3.7.4-VASP-5.4.4.eb
@@ -25,6 +25,7 @@ dependencies = [
 
 source_urls = ['https://github.com/zhongliliu/elastool/archive']
 sources = ['%(version)s.tar.gz']
+patches = ['elastool_examples.patch']
 checksums = ['83f56b70354c202c53b1322137cdb8c73a3b929582baeaef064f94695dd12635']
 
 skipsteps = ['configure', 'build']

--- a/easybuild/easyconfigs/e/elastool/elastool_examples.patch
+++ b/easybuild/easyconfigs/e/elastool/elastool_examples.patch
@@ -1,0 +1,117 @@
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/2D-highT/Graphene/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/2D-highT/Graphene/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/2D-highT/Graphene/elastool.in	2021-02-09 11:15:26.515894000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/2D-highT/Graphene/elastool.in	2021-02-09 11:32:06.726927611 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 500
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Al2O3-Trigonal/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Al2O3-Trigonal/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Al2O3-Trigonal/elastool.in	2021-02-09 11:15:27.514822000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Al2O3-Trigonal/elastool.in	2021-02-09 11:31:07.805303702 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/AuSe-2D/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/AuSe-2D/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/AuSe-2D/elastool.in	2021-02-09 11:15:27.498597000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/AuSe-2D/elastool.in	2021-02-09 11:31:07.808766036 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1000
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/CaMoO4-Tetragonal/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/CaMoO4-Tetragonal/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/CaMoO4-Tetragonal/elastool.in	2021-02-09 11:15:27.524359000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/CaMoO4-Tetragonal/elastool.in	2021-02-09 11:31:07.811619144 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Cu-highT/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Cu-highT/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Cu-highT/elastool.in	2021-02-09 11:15:27.468881000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Cu-highT/elastool.in	2021-02-09 11:31:07.814726532 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 500
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/diamond-Cubic/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/diamond-Cubic/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/diamond-Cubic/elastool.in	2021-02-09 11:15:26.316246000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/diamond-Cubic/elastool.in	2021-02-09 11:31:07.817758967 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Graphene/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Graphene/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Graphene/elastool.in	2021-02-09 11:15:26.505530000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Graphene/elastool.in	2021-02-09 11:31:07.821842997 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1000
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/MoS2-2D/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/MoS2-2D/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/MoS2-2D/elastool.in	2021-02-09 11:15:27.475192000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/MoS2-2D/elastool.in	2021-02-09 11:31:07.826485782 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1000
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Phosphorene/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Phosphorene/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/Phosphorene/elastool.in	2021-02-09 11:15:27.536433000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/Phosphorene/elastool.in	2021-02-09 11:31:07.830420771 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1000
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/SnO-2D/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/SnO-2D/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/SnO-2D/elastool.in	2021-02-09 11:15:26.326171000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/SnO-2D/elastool.in	2021-02-09 11:31:07.833823984 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1000
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/TiB2-Hexagonal/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/TiB2-Hexagonal/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/TiB2-Hexagonal/elastool.in	2021-02-09 11:15:27.456548000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/TiB2-Hexagonal/elastool.in	2021-02-09 11:31:07.835976415 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/TiSi2-orthorhombic/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/TiSi2-orthorhombic/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/TiSi2-orthorhombic/elastool.in	2021-02-09 11:15:26.307264000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/TiSi2-orthorhombic/elastool.in	2021-02-09 11:31:07.838762177 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 500
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp
+diff -ru elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/ZrO2-monoclinic/elastool.in elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/ZrO2-monoclinic/elastool.in
+--- elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b.orig/examples/ZrO2-monoclinic/elastool.in	2021-02-09 11:15:27.485111000 +0000
++++ elastool-7199f7acfb22d068cc55fcfc9c660617bf6f8c5b/examples/ZrO2-monoclinic/elastool.in	2021-02-09 11:31:07.840862776 +0000
+@@ -34,4 +34,4 @@
+ num_last_samples = 1
+ 
+ # The parallel submiting commmd
+-parallel_submit_command = mpirun -np 28 vasp544 > log.vasp
++parallel_submit_command = mpirun -np ${SLURM_NTASKS} vasp_std > log.vasp


### PR DESCRIPTION
For INC1103201 - rebuild/update for #490

Changed `mpirun -np 28 vasp544` to `mpirun -np ${SLURM_NTASKS} vasp_std`, so that the examples work.

* [x] Assigned to reviewer

`elastool-7199f7a-intel-2019b-Python-3.7.4-VASP-5.4.4.eb`
* [ ] EL7-cascadelake
* [ ] EL7-haswell

`elastool-7199f7a-iomkl-2019b-Python-3.7.4-VASP-5.4.4.eb`
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell