### PR TITLE
COMSOL 5.6

### DIFF
--- a/easybuild/easyconfigs/c/COMSOL/COMSOL-5.6.0.280.eb
+++ b/easybuild/easyconfigs/c/COMSOL/COMSOL-5.6.0.280.eb
@@ -1,0 +1,23 @@
+name = 'COMSOL'
+version = '5.6.0.280'
+
+homepage = 'https://www.comsol.com'
+description = """
+COMSOL Multiphysics is a general-purpose software platform, based on
+advanced numerical methods, for modeling and simulating physics-based
+problems.
+"""
+
+toolchain = SYSTEM
+
+# source tarball has to be created manually from dvd
+# mount -o ro path-to-iso /mnt
+# cd /mnt
+# tar zcf <path-to-sources>/COMSOL-5.6.0.280.tar.gz .
+# umount /mnt
+sources = [SOURCE_TAR_GZ]
+checksums = ['a5fbe1ef4b9b213885c5c423447b302a66d8bad673a707ec3fb9b33ae46a71f3']
+
+# license is required, can be specified via $LMCOMSOL_LICENSE_FILE
+
+moduleclass = 'phys'


### PR DESCRIPTION
For INC1101786 - `COMSOL-5.6.0.280.eb`

Requires https://github.com/bear-rsg/easybuild-easyblocks/pull/67

The licence server needs setting for installation:
`export LMCOMSOL_LICENSE_FILE=1718@eps-p-lic-07.adf.bham.ac.uk`

To add to documentation:
Note, to run the COMSOL GUI users will need to explicitly disable OpenGL rendering:
```
comsol -3drend sw
```

* [ ] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell