### PR TITLE
Togl 2.1, based on upstream 2.0 but with Fedora 2.1 rpm etc. to get v2.1

### DIFF
--- a/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
@@ -8,7 +8,9 @@ description = """A Tcl/Tk widget for OpenGL rendering."""
 
 toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
 
-source_urls = ['https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/33/Everything/source/tree/Packages/t/']
+source_urls = [
+    'https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/33/Everything/source/tree/Packages/t/',
+]
 sources = [{'filename': 'tcl-togl-%(version)s-0.9.cvs20170502.fc33.src.rpm',
             'extract_cmd': 'rpm2cpio %s | cpio -idm && tar xjf %(name)s-%(version)s-cvs20170502.tar.bz2'}]
 patches = [

--- a/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
@@ -13,7 +13,6 @@ sources = [{'filename': 'tcl-togl-%(version)s-0.9.cvs20170502.fc33.src.rpm',
             'extract_cmd': 'rpm2cpio %s | cpio -idm && tar xjf %(name)s-%(version)s-cvs20170502.tar.bz2'}]
 patches = [
     'Togl-2.1_configure.patch',
-#    'Togl-2.0_decl.patch',
 ]
 checksums = [
     'ce9c8802e6a5c9b390457bc69868bb2d28fbaa4115e808a1f2893225282246de',  # tcl-togl-2.1-0.9.cvs20170502.fc33.src.rpm

--- a/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/t/Togl/Togl-2.1-GCCcore-8.3.0.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'Togl'
+version = '2.1'
+
+homepage = 'https://sourceforge.net/projects/togl/'
+description = """A Tcl/Tk widget for OpenGL rendering."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = ['https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/33/Everything/source/tree/Packages/t/']
+sources = [{'filename': 'tcl-togl-%(version)s-0.9.cvs20170502.fc33.src.rpm',
+            'extract_cmd': 'rpm2cpio %s | cpio -idm && tar xjf %(name)s-%(version)s-cvs20170502.tar.bz2'}]
+patches = [
+    'Togl-2.1_configure.patch',
+#    'Togl-2.0_decl.patch',
+]
+checksums = [
+    'ce9c8802e6a5c9b390457bc69868bb2d28fbaa4115e808a1f2893225282246de',  # tcl-togl-2.1-0.9.cvs20170502.fc33.src.rpm
+    'f33ab577b0b4626e0abb8f9e11ad7a4bd6da7e2219abbcd5818ebf30e080b564',  # Togl-2.1_configure.patch
+]
+
+start_dir = name
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [
+    ('Mesa', '19.1.7'),
+    ('Tk', '8.6.9'),
+    ('Tcl', '8.6.9'),
+]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -DTOGL_USE_FONTS=0" && '
+
+configopts = "--prefix=%(installdir)s --exec-prefix=%(installdir)s "
+configopts += "--with-tcl=${EBROOTTCL}/lib --with-tk=${EBROOTTK}/lib"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/t/Togl/Togl-2.1_configure.patch
+++ b/easybuild/easyconfigs/t/Togl/Togl-2.1_configure.patch
@@ -1,0 +1,33 @@
+--- Togl/configure.orig	2010-05-15 02:10:02.000000000 +0100
++++ Togl/configure	2021-02-19 14:26:42.452802828 +0000
+@@ -5249,7 +5249,7 @@
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Tcl private include files" >&5
+ $as_echo_n "checking for Tcl private include files... " >&6; }
+ 
+-    TCL_SRC_DIR_NATIVE=`${CYGPATH} ${TCL_SRC_DIR}`
++    TCL_SRC_DIR_NATIVE=`${CYGPATH}`
+     TCL_TOP_DIR_NATIVE=\"${TCL_SRC_DIR_NATIVE}\"
+ 
+     # Check to see if tcl<Plat>Port.h isn't already with the public headers
+@@ -5404,7 +5404,7 @@
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Tk private include files" >&5
+ $as_echo_n "checking for Tk private include files... " >&6; }
+ 
+-    TK_SRC_DIR_NATIVE=`${CYGPATH} ${TK_SRC_DIR}`
++    TK_SRC_DIR_NATIVE=`${CYGPATH}`
+     TK_TOP_DIR_NATIVE=\"${TK_SRC_DIR_NATIVE}\"
+ 
+     # Check to see if tk<Plat>Port.h isn't already with the public headers
+@@ -5454,9 +5454,9 @@
+ 	    esac
+ 	    result="Using ${TK_INCLUDES}"
+ 	else
+-	    if test ! -f "${TK_SRC_DIR}/generic/tkInt.h" ; then
+-	       as_fn_error "Cannot find private header tkInt.h in ${TK_SRC_DIR}" "$LINENO" 5
+-	    fi
++	    #if test ! -f "${TK_SRC_DIR}/generic/tkInt.h" ; then
++	    #   as_fn_error "Cannot find private header tkInt.h in ${TK_SRC_DIR}" "$LINENO" 5
++	    #fi
+ 	    result="Using srcdir found in tkConfig.sh: ${TK_SRC_DIR}"
+ 	fi
+     fi


### PR DESCRIPTION
This is based on https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/t/Togl/Togl-2.0-GCCcore-8.3.0.eb and its configure patch. Togl 2.1 doesn't exist as a release in sourceforge, but Fedora includes it so we can get it from the source RPM...

For INC1105816 - `Togl-2.1-GCCcore-8.3.0.eb `

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL7.9-cascadelake
* [ ] EL7.9-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] Ubuntu16 VM
* [ ] Ubuntu20 VM
