### PR TITLE
Fixing snakemake SNAKEMAKE_LOAD_MODULE

### DIFF
--- a/easybuild/easyconfigs/s/snakemake/snakemake-5.31.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/snakemake/snakemake-5.31.1-foss-2020a-Python-3.8.2.eb
@@ -70,7 +70,7 @@ exts_list = [
 
 # site-specific: the line below is the command for loading this module with the (default) EB module naming scheme
 # if necessary, change this command to match your cluster setup
-local_snakemake_load = 'module load %(module_name)s'
+local_snakemake_load = 'module load %(name)s'
 modextravars = {'SNAKEMAKE_LOAD_MODULE': local_snakemake_load}
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/s/snakemake/snakemake-5.31.1-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/s/snakemake/snakemake-5.31.1-foss-2020a-Python-3.8.2.eb
@@ -70,7 +70,8 @@ exts_list = [
 
 # site-specific: the line below is the command for loading this module with the (default) EB module naming scheme
 # if necessary, change this command to match your cluster setup
-local_snakemake_load = 'module load %(name)s'
+local_snakemake_load = 'module load %(name)s/%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s'
+
 modextravars = {'SNAKEMAKE_LOAD_MODULE': local_snakemake_load}
 
 sanity_check_paths = {


### PR DESCRIPTION
rebuild `snakemake-5.31.1-foss-2020a-Python-3.8.2.eb` (module only)

The original module files literally said `module load %(module_name)s` - but I wonder if that's what snakemake expects?? I.e. is this a fix, or isn't it broken in the first place?

* [x] Assigned to reviewer

Default:
* [ ] EL7-cascadelake
* [ ] EL7-haswell
* [ ] EL8-cascadelake
* [ ] EL8-haswell

