### PR TITLE
fix NAG-FSL6I26DCL

### DIFF
--- a/easybuild/easyconfigs/n/NAG/NAG-FSL6I26DCL-iomkl-2019b.eb
+++ b/easybuild/easyconfigs/n/NAG/NAG-FSL6I26DCL-iomkl-2019b.eb
@@ -23,9 +23,10 @@ postinstallcmds = [
 ]
 
 modextravars = {
+    'NAG_FFLAGS': '-qopenmp',
     'NAG_FINCLUDE': '-I%(installdir)s/nag_interface_blocks',
     'NAG_FLINK': '%(installdir)s/lib/libnag_mkl.so '
-                 '-L%(installdir)s/mkl_intel64_11.3.3 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core '
+                 '-L%(installdir)s/mkl_intel64_11.3.3 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_def '
                  '-L%(installdir)s/rtl/intel64 -liomp5 -lpthread -lm -ldl',
 }
 


### PR DESCRIPTION
`NAG-FSL6I26DCL-iomkl-2019b.eb`

`-lmkl_def ` is needed in `$NAG_FLINK`.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
