### PR TITLE
PICI-LIGGGHTS

### DIFF
--- a/easybuild/easyconfigs/p/PICI-LIGGGHTS/PICI-LIGGGHTS-20210424-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/PICI-LIGGGHTS/PICI-LIGGGHTS-20210424-foss-2020a-Python-3.8.2.eb
@@ -1,0 +1,48 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'CMakeMake'
+name = 'PICI-LIGGGHTS'
+version = '20210424'
+_hash = '01d02ac'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://github.com/uob-positron-imaging-centre/PICI-LIGGGHTS"
+description = """UoB Postron Imaging Centre's Improved LIGGGHTS distribution with an emphasis on the Python
+interface"""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['https://github.com/uob-positron-imaging-centre/PICI-LIGGGHTS/archive/']
+sources = ['%s.tar.gz' % _hash]
+checksums = ['70dab875b53595bbe5d725f820eb32107eb7cc81be8a75cb557ef970c2e1fcd0']
+
+builddependencies = [('CMake', '3.16.4')]
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('libjpeg-turbo', '2.0.4'),
+    ('VTK', '8.2.0', versionsuffix),
+]
+
+start_dir = 'src'
+configopts = '-DVTK_DIR=$EBROOTVTK'
+postinstallcmds = [
+    "mkdir -p %(installdir)s/lib/python3.8/site-packages",
+    "cd %(builddir)s/%(name)s*/python && "  # continuation, so no comma here
+    "python install.py %(installdir)s/lib %(installdir)s/lib/python%(pyshortver)s/site-packages",
+    "cp -r %(builddir)s/%(name)s*/examples %(installdir)s/",
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['bin/liggghts', 'lib/libliggghts.a', 'lib/libliggghts.%s' % SHLIB_EXT],
+    'dirs': ['examples/LIGGGHTS/Tutorials_public', 'include'],
+}
+
+sanity_check_commands = [
+    'srun liggghts -help || true',  # non zero exit code
+    'python -c "import liggghts"',
+]
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/p/PICI-LIGGGHTS/PICI-LIGGGHTS-20210424-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/p/PICI-LIGGGHTS/PICI-LIGGGHTS-20210424-foss-2020a-Python-3.8.2.eb
@@ -41,7 +41,7 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = [
-    'srun liggghts -help || true',  # non zero exit code
+    'srun -n 1 liggghts -help || true',  # non zero exit code
     'python -c "import liggghts"',
 ]
 


### PR DESCRIPTION
For INC1125537 - `PICI-LIGGGHTS-20210424-foss-2020a-Python-3.8.2.eb`

Note: `srun` is needed with the new (non-fisbatch) interactive build jobs, when running an MPI application. Otherwise, you get an error: `srun: error: PMK_KVS_Barrier duplicate request from task 0`.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell