### PR TITLE
Fix typo in dirs

### DIFF
--- a/easybuild/easyconfigs/c/CLHEP/CLHEP-2.4.1.3-foss-2019b.eb
+++ b/easybuild/easyconfigs/c/CLHEP/CLHEP-2.4.1.3-foss-2019b.eb
@@ -25,7 +25,7 @@ sanity_check_paths = {
                                             'Matrix', 'Random', 'RandomObjects',
                                             'RefCount', 'Units', 'Utility',
                                             'Vector', 'clhep']],
-    'dirs': ['bin', 'lib, include'],
+    'dirs': ['bin', 'lib', 'include'],
 }
 
 configopts = '-DCMAKE_BUILD_TYPE=Release'


### PR DESCRIPTION
For INC1124583 - `GATE-9.0-foss-2019b-Python-3.7.4.eb`

Fix minor typo in #563

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell