### PR TITLE
Add Seaborn foss easyconfig

### DIFF
--- a/easybuild/easyconfigs/s/Seaborn/Seaborn-0.11.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/Seaborn/Seaborn-0.11.1-foss-2020b.eb
@@ -1,0 +1,29 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# Swiss Institute of Bioinformatics (SIB)
+# Biozentrum - University of Basel
+easyblock = 'PythonPackage'
+
+name = 'Seaborn'
+version = '0.11.1'
+
+homepage = 'https://seaborn.pydata.org/'
+description = """ Seaborn is a Python visualization library based on matplotlib.
+ It provides a high-level interface for drawing attractive statistical graphics. """
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['44e78eaed937c5a87fc7a892c329a7cc091060b67ebd1d0d306b446a74ba01ad']
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('matplotlib', '3.3.3'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1122984 - `seaborn-0.11.1-foss-2020b.eb`

Also need existing easyconfigs building for the same INC (but these are not dependencies of Seaborn):

`JupyterLab-2.2.8-GCCcore-10.2.0.eb`
`plotly.py-4.14.3-GCCcore-10.2.0.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell