### PR TITLE
add glew dependency to ROOT

### DIFF
--- a/easybuild/easyconfigs/g/glew/glew-2.1.0-GCCcore-8.3.0.eb
+++ b/easybuild/easyconfigs/g/glew/glew-2.1.0-GCCcore-8.3.0.eb
@@ -1,0 +1,42 @@
+# Contribution from the Crick HPC team
+# uploaded by J. Sassmannshausen
+
+easyblock = 'ConfigureMake'
+
+name = 'glew'
+version = '2.1.0'
+
+homepage = 'http://glew.sourceforge.net/'
+description = """The OpenGL Extension Wrangler Library
+
+The OpenGL Extension Wrangler Library (GLEW) is a cross-platform 
+open-source C/C++ extension loading library. GLEW provides 
+efficient run-time mechanisms for determining which OpenGL 
+extensions are supported on the target platform. OpenGL 
+core and extension functionality is exposed in a single header 
+file. GLEW has been tested on a variety of operating systems, 
+including Windows, Linux, Mac OS X, FreeBSD, Irix, and Solaris."""
+
+toolchain = {'name': 'GCCcore', 'version': '8.3.0'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(name)s-%(version)s.tgz']
+checksums = ['04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95']
+
+builddependencies = [('binutils', '2.32')]
+
+dependencies = [('Mesa', '19.1.7')]
+
+skipsteps = ['configure']
+
+preinstallopts = 'GLEW_PREFIX=%(installdir)s GLEW_DEST=%(installdir)s '
+install_cmd = 'make install.all'
+
+sanity_check_paths = {
+    'files': ['lib/libGLEW.a', 'lib/libGLEW.%s' % SHLIB_EXT] +
+             ['bin/glewinfo', 'bin/visualinfo'] +
+             ['include/GL/glew.h', 'include/GL/glxew.h', 'include/GL/wglew.h'],
+    'dirs': ['', ]
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/r/ROOT/ROOT-6.20.00-foss-2019b-Python-3.7.4.eb
+++ b/easybuild/easyconfigs/r/ROOT/ROOT-6.20.00-foss-2019b-Python-3.7.4.eb
@@ -37,6 +37,7 @@ dependencies = [
     ('libjpeg-turbo', '2.0.3'),
     ('zstd', '1.4.4'),
     ('tbb', '2019_U9'),
+    ('glew', '2.1.0'),
 ]
 
 # disable some components


### PR DESCRIPTION
For INC1122924 - Rebuild `ROOT-6.20.00-foss-2019b-Python-3.7.4.eb`

Add `glew` as a dependency of `ROOT`, as per https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/ROOT/ROOT-6.20.04-foss-2019b-Python-3.7.4.eb.

* [x] Assigned to reviewers (usually everyone in apps team)

* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM
