### PR TITLE
code-server 3.9.3 easyconf

### DIFF
--- a/easybuild/easyconfigs/c/code-server/code-server-3.9.3.eb
+++ b/easybuild/easyconfigs/c/code-server/code-server-3.9.3.eb
@@ -1,0 +1,13 @@
+name = 'code-server'
+version = '3.9.3'
+
+homepage = 'https://github.com/cdr/code-server'
+description = """Run VS Code on any machine anywhere and access it in the browser."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://github.com/cdr/code-server/releases/download/v%(version)s/']
+sources = ['code-server-%(version)s-linux-%(mapped_arch)s.tar.gz']
+checksums = ['eba42eaf868c2144795b1ac54929e3b252ae35403bf8553b3412a5ac4f365a41']
+
+moduleclass = 'tools'


### PR DESCRIPTION
Ticket: INC1127087 (N.B. closed by user)

`code-server-3.9.3.eb`

Requires easyblock: https://github.com/bear-rsg/easybuild-easyblocks/pull/78

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell