### PR TITLE
Mercurial-5.7.1-GCCcore-10.2.0.eb from upstream

### DIFF
--- a/easybuild/easyconfigs/m/Mercurial/Mercurial-5.7.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/m/Mercurial/Mercurial-5.7.1-GCCcore-10.2.0.eb
@@ -1,0 +1,31 @@
+##
+# Author:    Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+easyblock = "PythonPackage"
+
+name = 'Mercurial'
+version = '5.7.1'
+
+homepage = 'https://www.mercurial-scm.org'
+description = """Mercurial is a free, distributed source control management tool. It efficiently handles projects
+of any size and offers an easy and intuitive interface.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = ['https://www.mercurial-scm.org/release/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['cb5139144ccb2ef648f36963c8606d47dea1cb0e22aa2c055d6f860ce3fde7b0']
+
+dependencies = [
+    ('binutils', '2.35'),
+    ('Python', '3.8.6')
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+sanity_check_commands = ["hg --help"]
+
+moduleclass = 'tools'


### PR DESCRIPTION
Mercurial direct from https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/m/Mercurial/Mercurial-5.7.1-GCCcore-10.2.0.eb

For INC1121402 - `Mercurial-5.7.1-GCCcore-10.2.0.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] Ubuntu20 VM
