### PR TITLE
GROMACS 2021.2

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-foss-2020b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-foss-2020b.eb
@@ -1,0 +1,88 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2021.2'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a CPU only build, containing both MPI and threadMPI builds
+for both single and double precision.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch',
+    'GROMACS-2019_increase_test_timeout_for_GPU.patch',
+    'GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch',
+    'GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch',
+]
+checksums = [
+    'd940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb',  # gromacs-2021.2.tar.gz
+    # GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch
+    '406f5edd204be812f095a6f07ebc2673c5f6ddf1b1c1428fd336a80b9c629275',
+    # GROMACS-2019_increase_test_timeout_for_GPU.patch
+    '0d16f53d428155197a0ed0b0974ce03422f199d7c463c4a9156a3b99e3c86234',
+    # GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
+    'b7ffb292ec362e033db1bedd340353f0644dbaae872127750f3dda1ac7e87d49',
+    # GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch
+    '89fbb7e2754de45573632c74f53563bb979df9758c949238a35865391d6b53fb',
+]
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+    ('scikit-build', '0.11.1'),
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('networkx', '2.5'),
+]
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+}
+
+exts_list = [
+    ('gmxapi', '0.2.0', {
+        'preinstallopts': "export GMXTOOLCHAINDIR=%(installdir)s/share/cmake/gromacs_mpi && ",
+        'checksums': ['3954bf123da12fc60bcfaeed8263f5e2d3e16e5136c2bb5c8207b20fa7406788'],
+    }),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-fosscuda-2020b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-fosscuda-2020b.eb
@@ -1,0 +1,87 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2021.2'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI builds.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2020b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch',
+    'GROMACS-2019_increase_test_timeout_for_GPU.patch',
+    'GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch',
+    'GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch',
+]
+checksums = [
+    'd940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb',  # gromacs-2021.2.tar.gz
+    # GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch
+    '406f5edd204be812f095a6f07ebc2673c5f6ddf1b1c1428fd336a80b9c629275',
+    # GROMACS-2019_increase_test_timeout_for_GPU.patch
+    '0d16f53d428155197a0ed0b0974ce03422f199d7c463c4a9156a3b99e3c86234',
+    # GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
+    'b7ffb292ec362e033db1bedd340353f0644dbaae872127750f3dda1ac7e87d49',
+    # GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch
+    '89fbb7e2754de45573632c74f53563bb979df9758c949238a35865391d6b53fb',
+]
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+    ('scikit-build', '0.11.1'),
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('networkx', '2.5'),
+]
+
+exts_defaultclass = 'PythonPackage'
+
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+    'download_dep_fail': True,
+    'sanity_pip_check': True,
+}
+
+exts_list = [
+    ('gmxapi', '0.2.0', {
+        'preinstallopts': "export GMXTOOLCHAINDIR=%(installdir)s/share/cmake/gromacs_mpi && ",
+        'checksums': ['3954bf123da12fc60bcfaeed8263f5e2d3e16e5136c2bb5c8207b20fa7406788'],
+    }),
+]
+
+modextrapaths = {
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-iomkl-2020b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-iomkl-2020b.eb
@@ -1,0 +1,61 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2021.2'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a CPU only build, containing both MPI and threadMPI builds
+for both single and double precision.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'iomkl', 'version': '2020b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch',
+    'GROMACS-2019_increase_test_timeout_for_GPU.patch',
+    'GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch',
+    'GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch',
+]
+checksums = [
+    'd940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb',  # gromacs-2021.2.tar.gz
+    # GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch
+    '406f5edd204be812f095a6f07ebc2673c5f6ddf1b1c1428fd336a80b9c629275',
+    # GROMACS-2019_increase_test_timeout_for_GPU.patch
+    '0d16f53d428155197a0ed0b0974ce03422f199d7c463c4a9156a3b99e3c86234',
+    # GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
+    'b7ffb292ec362e033db1bedd340353f0644dbaae872127750f3dda1ac7e87d49',
+    # GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch
+    '89fbb7e2754de45573632c74f53563bb979df9758c949238a35865391d6b53fb',
+]
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-iomklc-2020b.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.2-iomklc-2020b.eb
@@ -1,0 +1,60 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2016 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC,
+#                                 Ghent University / The Francis Crick Institute
+# Authors::
+# * Wiktor Jurkowski <wiktor.jurkowski@gmail.com>
+# * Fotis Georgatos <fotis@cern.ch>
+# * George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# * Kenneth Hoste <kenneth.hoste@ugent.be>
+# * Adam Huffman <adam.huffman@crick.ac.uk>
+# * Ake Sandgren <ake.sandgren@hpc2n.umu.se>
+# * J. Sassmannshausen <Crick HPC team>
+# * Dugan Witherick <dugan.witherick@warwick.ac.uk>
+# License::   MIT/GPL
+
+name = 'GROMACS'
+version = '2021.2'
+
+homepage = 'https://www.gromacs.org'
+description = """
+GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the
+Newtonian equations of motion for systems with hundreds to millions of
+particles.
+
+This is a GPU enabled build, containing both MPI and threadMPI builds.
+
+It also contains the gmxapi extension for the single precision MPI build.
+"""
+
+toolchain = {'name': 'iomklc', 'version': '2020b'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://ftp.gromacs.org/pub/gromacs/',
+    'ftp://ftp.gromacs.org/pub/gromacs/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    'GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch',
+    'GROMACS-2019_increase_test_timeout_for_GPU.patch',
+    'GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch',
+    'GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch',
+]
+checksums = [
+    'd940d865ea91e78318043e71f229ce80d32b0dc578d64ee5aa2b1a4be801aadb',  # gromacs-2021.2.tar.gz
+    # GROMACS-2019_fix_omp_num_threads_and_google_test_death_style_in_tests.patch
+    '406f5edd204be812f095a6f07ebc2673c5f6ddf1b1c1428fd336a80b9c629275',
+    # GROMACS-2019_increase_test_timeout_for_GPU.patch
+    '0d16f53d428155197a0ed0b0974ce03422f199d7c463c4a9156a3b99e3c86234',
+    # GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
+    'b7ffb292ec362e033db1bedd340353f0644dbaae872127750f3dda1ac7e87d49',
+    # GROMACS-2020.5_fix_threads_gpu_Gmxapitests.patch
+    '89fbb7e2754de45573632c74f53563bb979df9758c949238a35865391d6b53fb',
+]
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021_fix_gmxapi_gmx_allowed_cmd_name.patch
@@ -1,0 +1,16 @@
+Fix search for "gmx" binary to allow for double precision builds.
+Updated for GROMACS 2021.
+
+Åke Sandgren, 20210223
+diff -ru gromacs-2021.orig/python_packaging/src/gmxapi/testsupport.py gromacs-2021/python_packaging/src/gmxapi/testsupport.py
+--- gromacs-2021.orig/python_packaging/src/gmxapi/testsupport.py	2021-01-28 14:36:50.000000000 +0100
++++ gromacs-2021/python_packaging/src/gmxapi/testsupport.py	2021-02-23 13:16:04.821413423 +0100
+@@ -267,7 +267,7 @@
+             command = None
+ 
+         # TODO: Remove fall-back when we can rely on gmxconfig.json via importlib.resources in Py 3.7+.
+-        allowed_command_names = ['gmx', 'gmx_mpi']
++        allowed_command_names = ['gmx%s%s' % (m, p) for m in ['', '_mpi'] for p in ['', '_d']]
+         for command_name in allowed_command_names:
+             if command is not None:
+                 break


### PR DESCRIPTION
For ExCALIBUR

Please also see https://github.com/bear-rsg/easybuild-easyblocks/pull/83

* [x] Assigned to reviewers (usually everyone in apps team)

NOTE: will not work with `srun`.

`GROMACS-2021.2-foss-2020b.eb GROMACS-2021.2-iomkl-2020b.eb`
* [ ] EL8-cascadelake

`GROMACS-2021.2-foss-2020b.eb GROMACS-2021.2-fosscuda-2020b.eb GROMACS-2021.2-iomkl-2020b.eb GROMACS-2021.2-iomklc-2020b.eb`
* [ ] EL8-haswell

The `gmxapi` Python package gives errors like the following when building with`intel`, so it has been left out of the `iomkl` and `iomklc` easyconfigs:
```
/pip-req-build-9uqxaf9o/external/pybind/include/pybind11/cast.h(2159): error: no instance of overloaded function "pybind11::detail::collect_arguments" matches the argument list
               argument types are: (pybind11::object)
         return detail::collect_arguments<policy>(std::forward<Args>(args)...).call(derived().ptr());
```
The errors persist when switching off the internal `pybind11` (version 2.2) and using `pybind11/2.6.0-GCCcore-10.2.0` as a dependency.