### PR TITLE
 VASP 5.4.4 2020b

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomkl-2020b.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomkl-2020b.eb
@@ -1,0 +1,44 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+
+homepage = "https://www.vasp.at"
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale
+ materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics,
+ from first principles."""
+
+toolchain = {'name': 'iomkl', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+# source_urls = []
+# VASP is proprietary software. For installation purposes please download from https://www.vasp.at/vasp-portal
+# using the RSG's installation licence.
+sources = ['vasp.5.4.4.pl2.tgz']
+
+# Note that the file diff.patch in the downloaded archive tar.gz has already been applied.
+patches = []
+
+checksums = ['98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e']
+
+prebuildopts = "unset LIBS && cp arch/makefile.include.linux_intel makefile.include && "
+prebuildopts += "sed -i s/mpiifort/mpifort/ makefile.include && "
+prebuildopts += "sed -i s/-lmkl_blacs_intelmpi_lp64/-lmkl_blacs_openmpi_lp64/ makefile.include && "
+prebuildopts += "sed -i s:\$\(I_MPI_ROOT\)/include64/:\$\(MPI_HOME\)/include/: makefile.include && "
+# build type
+buildopts = 'all'
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+files_to_copy = [(['./bin/vasp_*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam', 'bin/vasp_ncl', 'bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'
+
+local_bham_group = "p-vasp"

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomklc-2020b.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomklc-2020b.eb
@@ -1,0 +1,48 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+
+homepage = "https://www.vasp.at"
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale
+ materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics,
+ from first principles."""
+
+toolchain = {'name': 'iomklc', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+# source_urls = []
+# VASP is proprietary software. For installation purposes please download from https://www.vasp.at/vasp-portal
+# using the RSG's installation licence.
+sources = ['vasp.5.4.4.pl2.tgz']
+patches = [
+    'VASP-5.4.4_intel-gpu.patch',
+]
+checksums = [
+    '98f75fd75399a23d76d060a6155f4416b340a1704f256a00146f89024035bc8e',  # vasp.5.4.4.pl2.tgz
+    '736053fec404e41a30b17d67ee490e16d14a829f7a43e34da94cd2830f3c306e',  # VASP-5.4.4_intel-gpu.patch
+]
+
+# Note that the file diff.patch in the downloaded archive tar.gz has already been applied.
+prebuildopts = "unset LIBS && cp arch/makefile.include.linux_intel makefile.include && "
+prebuildopts += "sed -i s/mpiifort/mpifort/ makefile.include && "
+prebuildopts += "sed -i s/-lmkl_blacs_intelmpi_lp64/-lmkl_blacs_openmpi_lp64/ makefile.include && "
+prebuildopts += "sed -i s:\$\(I_MPI_ROOT\)/include64/:\$\(MPI_HOME\)/include/: makefile.include && "
+# build type
+buildopts = "gpu gpu_ncl CUDA_ROOT=$EBROOTCUDA "
+buildopts += "GENCODE_ARCH='-gencode=arch=compute_60,code=sm_60'"  # doesn't work with sm_70
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+files_to_copy = [(['./bin/vasp_*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu', 'bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'
+
+local_bham_group = "p-vasp"

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomklc-2020b.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-iomklc-2020b.eb
@@ -16,6 +16,7 @@ toolchainopts = {'usempi': True}
 # VASP is proprietary software. For installation purposes please download from https://www.vasp.at/vasp-portal
 # using the RSG's installation licence.
 sources = ['vasp.5.4.4.pl2.tgz']
+# Note that the file diff.patch in the downloaded archive tar.gz has already been applied.
 patches = [
     'VASP-5.4.4_intel-gpu.patch',
 ]
@@ -24,7 +25,6 @@ checksums = [
     '736053fec404e41a30b17d67ee490e16d14a829f7a43e34da94cd2830f3c306e',  # VASP-5.4.4_intel-gpu.patch
 ]
 
-# Note that the file diff.patch in the downloaded archive tar.gz has already been applied.
 prebuildopts = "unset LIBS && cp arch/makefile.include.linux_intel makefile.include && "
 prebuildopts += "sed -i s/mpiifort/mpifort/ makefile.include && "
 prebuildopts += "sed -i s/-lmkl_blacs_intelmpi_lp64/-lmkl_blacs_openmpi_lp64/ makefile.include && "

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4_intel-gpu.patch
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4_intel-gpu.patch
@@ -1,0 +1,20 @@
+diff -Nru vasp.5.4.4.pl2.orig/arch/makefile.include.linux_intel vasp.5.4.4.pl2/arch/makefile.include.linux_intel
+--- vasp.5.4.4.pl2.orig/arch/makefile.include.linux_intel	2021-01-22 19:51:02.942571000 +0000
++++ vasp.5.4.4.pl2/arch/makefile.include.linux_intel	2021-05-27 12:51:24.198792000 +0100
+@@ -66,13 +66,13 @@
+ 
+ CC         = icc
+ CXX        = icpc
+-CFLAGS     = -fPIC -DADD_ -Wall -openmp -DMAGMA_WITH_MKL -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
++CFLAGS     = -fPIC -DADD_ -Wall -qopenmp -DMAGMA_WITH_MKL -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
+ 
+ CUDA_ROOT  ?= /usr/local/cuda/
+-NVCC       := $(CUDA_ROOT)/bin/nvcc -ccbin=icc
++NVCC       := $(CUDA_ROOT)/bin/nvcc -ccbin=icc -std=c++11
+ CUDA_LIB   := -L$(CUDA_ROOT)/lib64 -lnvToolsExt -lcudart -lcuda -lcufft -lcublas
+ 
+-GENCODE_ARCH    := -gencode=arch=compute_30,code=\"sm_30,compute_30\" \
++GENCODE_ARCH    ?= -gencode=arch=compute_30,code=\"sm_30,compute_30\" \
+                    -gencode=arch=compute_35,code=\"sm_35,compute_35\" \
+                    -gencode=arch=compute_60,code=\"sm_60,compute_60\"
+ 


### PR DESCRIPTION
For ExCALIBUR

* [x] Assigned to reviewers (usually everyone in apps team)

NOTE: the installation will not work with `srun`.

`VASP-5.4.4-iomkl-2020b.eb`
* [ ] EL8-cascadelake

`VASP-5.4.4-iomkl-2020b.eb VASP-5.4.4-iomklc-2020b.eb`
* [ ] EL8-haswell


Notes on the CUDA version:

The inclusion of the `cublas.h` header file in `src/CUDA/potlok.cu` leads to the following error when compiled with `nvcc -ccbin=icc` in 2020b: 
```
/rds/bear-apps/2020b/EL8-has/software/GCCcore/10.2.0/include/c++/10.2.0/type_traits(588): error: invalid combination of type specifiers
  template< class _Tp> using __is_signed_integer = __is_one_of< __remove_cv_t< _Tp> , signed char, signed short, signed int, signed long, signed long long, signed __int128_t> ;
``` 
Compiling with `nvcc -ccbin=icc -std=c++11` fixes this.

`GENCODE_ARCH` has been changed, as `sm_30` and `sm_35` are deprecated. `sm_70` (Volta) and `sm_80` (Ampere) don't work (`Instruction 'shfl' without '.sync' is not supported on .target sm_70`).
