### PR TITLE
Add plotly.py to BEAR DataScience module

### DIFF
--- a/easybuild/easyconfigs/b/BEAR-Python-DataScience/BEAR-Python-DataScience-2020a-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/b/BEAR-Python-DataScience/BEAR-Python-DataScience-2020a-foss-2020a-Python-3.8.2.eb
@@ -18,6 +18,7 @@ dependencies = [
     ('pept', '0.3.2', versionsuffix),
     ('OpenCV', '4.4.0', versionsuffix),
     ('NLopt', '2.6.1', versionsuffix),
+    ('plotly.py', '4.8.1'),
 ]
 
 moduleclass = 'tools'


### PR DESCRIPTION
For INC1134506 - `BEAR-Python-DataScience-2020a-foss-2020a-Python-3.8.2.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
