### PR TITLE
MATLAB/Simulink fix

### DIFF
--- a/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.4.eb
+++ b/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.4.eb
@@ -1,0 +1,24 @@
+easyblock = 'ConfigureMake'
+
+name = 'alsa-lib'
+version = '1.2.4'
+
+homepage = 'https://www.alsa-project.org'
+description = """The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality
+ to the Linux operating system."""
+
+toolchain = SYSTEM
+
+source_urls = ['ftp://ftp.alsa-project.org/pub/lib/']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['f7554be1a56cdff468b58fc1c29b95b64864c590038dd309c7a978c7116908f7']
+
+dependencies = [('binutils', '2.32')]
+
+sanity_check_paths = {
+    'files': ['bin/aserver', 'include/asoundlib.h',
+              'lib64/libatopology.%s' % SHLIB_EXT, 'lib64/libasound.%s' % SHLIB_EXT],
+    'dirs': ['include/alsa', 'lib/pkgconfig', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.4.eb
+++ b/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.4.eb
@@ -13,8 +13,6 @@ source_urls = ['ftp://ftp.alsa-project.org/pub/lib/']
 sources = [SOURCE_TAR_BZ2]
 checksums = ['f7554be1a56cdff468b58fc1c29b95b64864c590038dd309c7a978c7116908f7']
 
-dependencies = [('binutils', '2.32')]
-
 sanity_check_paths = {
     'files': ['bin/aserver', 'include/asoundlib.h',
               'lib64/libatopology.%s' % SHLIB_EXT, 'lib64/libasound.%s' % SHLIB_EXT],

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-2020a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-2020a.eb
@@ -13,10 +13,18 @@ toolchain = SYSTEM
 sources = [SOURCELOWER_TAR_GZ]
 checksums = ['29a336f47ae1a1ff723f7a841cae1b767f460115599f1c106f7940bc62df8d90']
 
-dependencies = [('Java', '1.8')]
+dependencies = [
+    ('Java', '1.8'),
+    ('alsa-lib', '1.2.4'),  # libasound.so.2 is needed for simulink
+]
 
 # MATLAB 2020a requires more Java memory at build time:
 java_options = '-Xmx2048m'
+
+# use system libcrypto.so.1.1 to avoid
+# /lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b
+# when running simulink
+postinstallcmds = ['cd %(installdir)s/bin/glnxa64 && for f in libcrypto.so.*; do mv $f $f.orig; done']
 
 # We encode a dummy licence server host/port here and then set the MLM_LICENSE_FILE environment
 # variable with the correct details in the BlueBEAR licences module

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -880,7 +880,7 @@ def template_easyconfig_test(self, spec):
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)
         if ec['toolchain']['version'] == 'system':
-            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils', 'alsa-lib']
+            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils', 'alsa-lib', 'MATLAB']
             requires_binutils &= bool(ec['name'] not in binutils_complete_dependencies)
 
         # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -880,7 +880,7 @@ def template_easyconfig_test(self, spec):
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)
         if ec['toolchain']['version'] == 'system':
-            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils', 'alsa-lib', 'MATLAB']
+            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils']
             requires_binutils &= bool(ec['name'] not in binutils_complete_dependencies)
 
         # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -880,7 +880,7 @@ def template_easyconfig_test(self, spec):
         # let's also exclude the very special case where the system GCC is used as GCCcore, and only apply this
         # exception to the dependencies of binutils (since we should eventually build a new binutils with GCCcore)
         if ec['toolchain']['version'] == 'system':
-            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils']
+            binutils_complete_dependencies = ['M4', 'Bison', 'flex', 'help2man', 'zlib', 'binutils', 'alsa-lib']
             requires_binutils &= bool(ec['name'] not in binutils_complete_dependencies)
 
         # if no sources/extensions/components are specified, it's just a bundle (nothing is being compiled)


### PR DESCRIPTION
For INC1135787:
1. build: `alsa-lib-1.2.4.eb`
2. module only build of `MATLAB-2020a.eb`
3. manually do the MATLAB postinstall step

Note: `$EB_MATLAB_KEY` needs to be set before building.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM

`alsa-lib-1.2.4.eb` provides `libasound.so.2`, which is needed for `Simulink`. The easyconfig is from upstream, but it has been changed to use the `SYSTEM` toolchain. `binutils` has also been removed from the dependencies, to avoid a conflict with `Dynare/4.6.3-foss-2019b` depending on `binutils/2.32` and `binutils/2.32-GCCcore-8.3.0`.

Moving aside `libcrypto.so.*` from `bin/glnxa64`, and using the system version instead, fixes `/lib64/libk5crypto.so.3: undefined symbol: EVP_KDF_ctrl, version OPENSSL_1_1_1b` when running `Simulink`.