### PR TITLE
LAMMPS 29Oct2020 in 2020b

### DIFF
--- a/easybuild/easyconfigs/a/archspec/archspec-0.1.0-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/a/archspec/archspec-0.1.0-GCCcore-10.2.0.eb
@@ -1,0 +1,26 @@
+easyblock = 'PythonPackage'
+
+name = 'archspec'
+version = '0.1.0'
+
+homepage = 'https://github.com/archspec/archspec'
+description = "A library for detecting, labeling, and reasoning about microarchitectures"
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+sources = ['archspec-%(version)s-py2.py3-none-any.whl']
+checksums = ['12f2029f63ffbc560e43f7d1f366a45ff46c7bd0751653227f8015f83f121119']
+
+builddependencies = [('binutils', '2.35')]
+
+dependencies = [('Python', '3.8.6')]
+
+unpack_sources = False
+download_dep_fail = True
+use_pip = True
+
+sanity_check_commands = ["python -c 'from archspec.cpu import host; print(host())'"]
+
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/e/Eigen/Eigen-3.3.9-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/e/Eigen/Eigen-3.3.9-GCCcore-10.2.0.eb
@@ -1,0 +1,21 @@
+name = 'Eigen'
+version = '3.3.9'
+
+homepage = 'https://eigen.tuxfamily.org'
+description = """Eigen is a C++ template library for linear algebra: matrices, vectors, numerical solvers,
+ and related algorithms."""
+
+# only includes header files, but requires CMake so using non-system toolchain
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = ['https://gitlab.com/libeigen/eigen/-/archive/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['0fa5cafe78f66d2b501b43016858070d52ba47bd9b1016b0165a7b8e04675677']
+
+# using CMake built with GCCcore to avoid relying on the system compiler to build it
+builddependencies = [
+    ('binutils', '2.35'),  # to make CMake compiler health check pass on old systems
+    ('CMake', '3.18.4'),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.10.0-foss-2020b.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'h5py'
+version = '2.10.0'
+
+homepage = 'https://www.h5py.org/'
+description = """HDF5 for Python (h5py) is a general-purpose Python interface to the Hierarchical Data Format library,
+ version 5. HDF5 is a versatile, mature scientific software library designed for the fast, flexible storage of enormous
+ amounts of data."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+patches = ['h5py-%(version)s_avoid-mpi-init.patch']
+checksums = [
+    '84412798925dc870ffd7107f045d7659e60f5d46d1c70c700375248bf6bf512d',  # h5py-2.10.0.tar.gz
+    '6bacb71f5d9fbd7bd9a01018d7fe21b067a2317f33c4a7c21fde9cd404c1603f',  # h5py-2.10.0_avoid-mpi-init.patch
+]
+
+builddependencies = [('pkgconfig', '1.5.1', '-python')]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('HDF5', '1.10.7'),
+]
+
+use_pip = True
+sanity_pip_check = True
+download_dep_fail = True
+
+preinstallopts = 'HDF5_MPI=ON HDF5_DIR="$EBROOTHDF5" '
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct2020-foss-2020b-kokkos.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct2020-foss-2020b-kokkos.eb
@@ -1,0 +1,101 @@
+name = 'LAMMPS'
+version = '29Oct2020'
+versionsuffix = '-kokkos'
+
+homepage = 'https://lammps.sandia.gov/'
+description = """LAMMPS is a classical molecular dynamics code, and an acronym
+for Large-scale Atomic/Molecular Massively Parallel Simulator. LAMMPS has
+potentials for solid-state materials (metals, semiconductors) and soft matter
+(biomolecules, polymers) and coarse-grained or mesoscopic systems. It can be
+used to model atoms or, more generically, as a parallel particle simulator at
+the atomic, meso, or continuum scale. LAMMPS runs on single processors or in
+parallel using message-passing techniques and a spatial-decomposition of the
+simulation domain. The code is designed to be easy to modify or extend with new
+functionality.
+"""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'openmp': True, 'usempi': True, 'cstd': 'c++11'}
+
+# 'https://github.com/lammps/lammps/archive/'
+source_urls = [GITHUB_LOWER_SOURCE]
+sources = [
+    'stable_%(version)s.tar.gz',
+    {'filename': 'lammps_vs_yaff_test_single_point_energy.py', 'extract_cmd': "cp %s %(builddir)s"},
+]
+patches = ['LAMMPS-29Oct2020_VTK9.patch']
+checksums = [
+    '759705e16c1fedd6aa6e07d028cc0c78d73c76b76736668420946a74050c3726',  # stable_29Oct2020.tar.gz
+    'c28fa5a1ea9608e4fd8686937be501c3bed8cc03ce1956f1cf0a1efce2c75349',  # lammps_vs_yaff_test_single_point_energy.py
+    '1baf5c1509e945b4a4aa1ea08ac3799f55d101bef824aa5bddbf759491491351',  # LAMMPS-29Oct2020_VTK9.patch
+]
+
+# see https://github.com/lammps/lammps/pull/1483 for why this is needed
+local_source_dir_name = '%(namelower)s-%(version)s'
+
+builddependencies = [
+    ('CMake', '3.18.4'),
+    ('pkg-config', '0.29.2'),
+    ('archspec', '0.1.0'),
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('libpng', '1.6.37'),
+    ('libjpeg-turbo', '2.0.5'),
+    ('netCDF', '4.7.4'),
+    ('GSL', '2.6'),
+    ('zlib', '1.2.11'),
+    ('gzip', '1.10'),
+    ('cURL', '7.72.0'),
+    ('HDF5', '1.10.7'),
+    ('tbb', '2020.3'),
+    ('PCRE', '8.44'),
+    ('libxml2', '2.9.10'),
+    ('FFmpeg', '4.3.1'),
+    ('Voro++', '0.4.6'),
+    ('kim-api', '2.2.1'),
+    ('Eigen', '3.3.9'),
+    ('yaff', '1.6.0'),
+    ('PLUMED', '2.6.2'),
+    ('ScaFaCoS', '1.0.1'),
+    ('VTK', '9.0.1'),
+]
+
+# To use additional custom configuration options, use the 'configopts' easyconfig parameter
+# See docs and lammps easyblock for more information.
+# https://github.com/lammps/lammps/blob/master/cmake/README.md#lammps-configuration-options
+# The docs build with a python virtualenv that doesn't seem to work in Python 3.8 - so disable them.
+configopts = "-DBUILD_DOC=no "
+
+# auto-enabled by easyblock
+# 'GPU'    - if cuda package is present and kokkos is disabled
+# 'KOKKOS' - if kokkos is enabled (by default)
+#
+# not enabled (yet), needs more work/additional dependencies:
+# 'LATTE', - https://lammps.sandia.gov/doc/Build_extras.html#latte-package
+# 'MSCG',  - https://lammps.sandia.gov/doc/Build_extras.html#mscg-package
+general_packages = [
+    'ASPHERE', 'BODY', 'CLASS2', 'COLLOID', 'COMPRESS', 'CORESHELL', 'DIPOLE',
+    'GRANULAR', 'KIM', 'KSPACE', 'MANYBODY', 'MC', 'MESSAGE', 'MISC',
+    'MOLECULE', 'MPIIO', 'PERI', 'POEMS', 'PYTHON', 'QEQ', 'REPLICA', 'RIGID',
+    'SHOCK', 'SNAP', 'SPIN', 'SRD', 'VORONOI',
+]
+
+# not enabled (yet), needs more work/additional dependencies:
+# ADIOS - https://lammps.sandia.gov/doc/Build_extras.html#user-adios-package
+# QUIP  - https://lammps.sandia.gov/doc/Build_extras.html#user-quip-package
+user_packages = [
+    'ATC', 'AWPMD', 'BOCS', 'CGDNA', 'CGSDK', 'COLVARS', 'DIFFRACTION', 'DPD', 'DRUDE',
+    'EFF', 'FEP', 'H5MD', 'LB', 'MANIFOLD', 'MEAMC', 'MESO', 'MGPT', 'MISC',
+    'MOFFF', 'MOLFILE', 'NETCDF', 'PHONON', 'PLUMED', 'PTM', 'QTB', 'REAXC',
+    'SCAFACOS', 'SDPD', 'SMD', 'SMTBQ', 'SPH', 'TALLY', 'UEF', 'YAFF', 'VTK'
+]
+
+enhance_sanity_check = True
+
+# run short test case to make sure installation doesn't produce blatently incorrect results;
+# this catches a problem where having the USER-INTEL package enabled causes trouble when installing with intel/2019b
+sanity_check_commands = ["cd %(builddir)s && python lammps_vs_yaff_test_single_point_energy.py"]
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct2020_VTK9.patch
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct2020_VTK9.patch
@@ -1,0 +1,12 @@
+diff -Nru lammps-stable_29Oct2020.orig/src/USER-VTK/dump_vtk.cpp lammps-stable_29Oct2020/src/USER-VTK/dump_vtk.cpp
+--- lammps-stable_29Oct2020.orig/src/USER-VTK/dump_vtk.cpp	2021-06-10 16:44:39.847838000 +0100
++++ lammps-stable_29Oct2020/src/USER-VTK/dump_vtk.cpp	2021-06-10 17:21:23.900896198 +0100
+@@ -93,7 +93,7 @@
+ #define ONEFIELD 32
+ #define DELTA 1048576
+ 
+-#if (VTK_MAJOR_VERSION < 5) || (VTK_MAJOR_VERSION > 8)
++#if (VTK_MAJOR_VERSION < 5) || (VTK_MAJOR_VERSION > 9)
+ #error This code has only been tested with VTK 5, 6, 7, and 8
+ #elif VTK_MAJOR_VERSION > 6
+ #define InsertNextTupleValue InsertNextTypedTuple

--- a/easybuild/easyconfigs/m/molmod/molmod-1.4.5-foss-2020b.eb
+++ b/easybuild/easyconfigs/m/molmod/molmod-1.4.5-foss-2020b.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'molmod'
+version = '1.4.5'
+
+homepage = 'https://molmod.github.io/molmod/'
+description = "MolMod is a Python library with many compoments that are useful to write molecular modeling programs."
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = ['https://github.com/molmod/molmod/releases/download/%(version)s']
+sources = [SOURCE_TAR_GZ]
+patches = ['molmod-1.4.5_deprecated_time_method.patch']
+checksums = [
+    '69c625fe081ea498371642d6237a8958cfc89608908fa8daa475f5d9dc5dc47c',  # molmod-1.4.5.tar.gz
+    '7de0dae2accd908ff7b40f5f848ffabdb9267dadbfb8cc4d2d98444995282e2d',  # molmod-1.4.5_deprecated_time_method.patch
+]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('matplotlib', '3.3.3'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+runtest = "export MATPLOTLIBRC=$PWD; echo 'backend: agg' > $MATPLOTLIBRC/matplotlibrc;"
+runtest += "python setup.py build_ext -i; nosetests -v"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/ScaFaCoS/ScaFaCoS-1.0.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/s/ScaFaCoS/ScaFaCoS-1.0.1-foss-2020b.eb
@@ -1,0 +1,44 @@
+easyblock = 'ConfigureMake'
+
+name = 'ScaFaCoS'
+version = '1.0.1'
+
+homepage = 'http://www.scafacos.de/'
+description = """ScaFaCoS is a library of scalable fast coulomb solvers."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [
+    '2b125f313795c81b0e87eb920082e91addf94c17444f9486d979e691aaded99b',  # scafacos-1.0.1.tar.gz
+]
+
+builddependencies = [
+    ('Autotools', '20200321'),
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('GMP', '6.2.0'),
+    ('GSL', '2.6'),
+]
+
+preconfigopts = 'unset F77 && '
+
+configopts = '--enable-shared --enable-static --disable-doc '
+# tell it where to find provided FFTW
+configopts += '--without-internal-fftw --with-fftw3-includedir=$EBROOTFFTW/include --with-fftw3-libdir=$EBROOTFFTW/lib '
+# only include the solvers supported for LAMMPS
+# (for p2nfft we need an additonal dependency)
+configopts += '--enable-fcs-solvers=direct,ewald,fmm,p3m '
+# -fallow-argument-mismatch needed with GCC 10
+configopts += 'FCFLAGS="$FCFLAGS -fallow-argument-mismatch" '
+
+sanity_check_paths = {
+    'files': ['lib/libfcs.a', 'include/fcs.h', 'include/fcs_module.mod'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/v/VTK/VTK-9.0.1-foss-2020b.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.0.1-foss-2020b.eb
@@ -1,0 +1,92 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# https://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-97.html
+##
+
+easyblock = 'CMakeMake'
+
+name = 'VTK'
+version = '9.0.1'
+
+homepage = 'https://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    SOURCE_TAR_GZ,
+    '%(name)sData-%(version)s.tar.gz',
+]
+patches = [('vtk-version.egg-info', '.')]
+checksums = [
+    '1b39a5e191c282861e7af4101eaa8585969a2de05f5646c9199a161213a622c7',  # VTK-9.0.1.tar.gz
+    '3f8bfdadd66e0b541bc5580340481abf92bec100b09d787283632ab590b1ce1c',  # VTKData-9.0.1.tar.gz
+    '787b82415ae7a4a1f815b4db0e25f7abc809a05fc85d7d219627f3a7e5d3867b',  # vtk-version.egg-info
+]
+
+builddependencies = [('CMake', '3.18.4')]
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('SciPy-bundle', '2020.11'),
+    ('XZ', '5.2.5'),
+    ('libGLU', '9.0.1'),
+    ('X11', '20201008'),
+]
+
+separate_build_dir = True
+
+# OpenGL
+configopts = "-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s " % SHLIB_EXT
+configopts += "-DOPENGL_gl_LIBRARY=$EBROOTMESA/lib/libGL.%s " % SHLIB_EXT
+configopts += "-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include "
+# Python
+configopts += "-DVTK_WRAP_PYTHON=ON -DVTK_PYTHON_VERSION=3 -DVTK_PYTHON_OPTIONAL_LINK=OFF "
+# Other
+configopts += "-DVTK_USE_MPI=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib"
+
+preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
+
+# Install a egg-info file so VTK is more python friendly, required for mayavi
+local_egg_info_src = '%(builddir)s/VTK-%(version)s/vtk-version.egg-info'
+local_egg_info_dest = '%(installdir)s/lib/python%(pyshortver)s/site-packages/vtk-%(version)s.egg-info'
+postinstallcmds = [
+    'sed "s/#VTK_VERSION#/%%(version)s/" %s > %s' % (local_egg_info_src, local_egg_info_dest),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+local_vtk_exec = ['vtk%s-%%(version_major_minor)s' % x
+                  for x in ['WrapJava', 'ParseJava', 'WrapPythonInit', 'WrapPython', 'WrapHierarchy']]
+local_vtk_exec += ['vtkpython']
+local_vtk_libs = ['CommonCore', 'IONetCDF', 'ParallelCore', 'RenderingOpenGL2']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_vtk_exec] + ['include/vtk-%(version_major_minor)s/vtkMPI.h'] +
+             ['lib/libvtk%s-%%(version_major_minor)s.%s' % (l, SHLIB_EXT) for l in local_vtk_libs],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/', 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [
+    "python -c 'import %(namelower)s'",
+    "python -c 'import pkg_resources; pkg_resources.get_distribution(\"vtk\")'",
+    # make sure that VTK Python libraries link to libpython (controlled via DVTK_PYTHON_OPTIONAL_LINK=OFF),
+    # see https://gitlab.kitware.com/vtk/vtk/-/issues/17881
+    "ldd $EBROOTVTK/lib/libvtkPythonContext2D-%%(version_major_minor)s.%s | grep /libpython" % SHLIB_EXT,
+]
+
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/v/Voro++/Voro++-0.4.6-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/v/Voro++/Voro++-0.4.6-GCCcore-10.2.0.eb
@@ -1,0 +1,37 @@
+
+easyblock = 'ConfigureMake'
+
+name = 'Voro++'
+version = '0.4.6'
+
+homepage = 'http://math.lbl.gov/voro++/'
+description = """Voro++ is a software library for carrying out three-dimensional computations of the Voronoi
+tessellation. A distinguishing feature of the Voro++ library is that it carries out cell-based calculations,
+computing the Voronoi cell for each particle individually. It is particularly well-suited for applications that
+rely on cell-based statistics, where features of Voronoi cells (eg. volume, centroid, number of faces) can be used
+to analyze a system of particles."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://math.lbl.gov/voro++/download/dir/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ef7970071ee2ce3800daa8723649ca069dc4c71cc25f0f7d22552387f3ea437e']
+builddependencies = [('binutils', '2.35')]
+
+
+# No configure
+skipsteps = ['configure']
+
+# Override CXX and CFLAGS variables from Makefile
+buildopts = 'CXX="$CXX" CFLAGS="$CXXFLAGS"'
+
+# Override PREFIX variable from Makefile
+installopts = "PREFIX=%(installdir)s"
+
+sanity_check_paths = {
+    'files': ['bin/voro++', 'lib/libvoro++.a', 'include/voro++/voro++.hh'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/y/yaff/yaff-1.6.0-foss-2020b.eb
+++ b/easybuild/easyconfigs/y/yaff/yaff-1.6.0-foss-2020b.eb
@@ -1,0 +1,41 @@
+# Updated from previous config
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+#
+# Building this in interactive Slurm session will result in freeze during either
+# runtest phase or sanity_check_commands phase (python -c 'import yaff')
+#
+# If you submit this as non-interactive Slurm job, it will build just fine.
+# Possibly root cause: https://github.com/h5py/h5py/issues/917
+#
+easyblock = 'PythonPackage'
+
+name = 'yaff'
+version = '1.6.0'
+
+homepage = 'https://molmod.github.io/yaff/'
+description = """Yaff stands for 'Yet another force field'. It is a pythonic force-field code."""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = ['https://github.com/molmod/yaff/releases/download/%(version)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['a266ab032778e37bb2e93152aefb67f396827aa728151651403984429c74ceaa']
+
+dependencies = [
+    ('Python', '3.8.6'),
+    ('h5py', '2.10.0'),
+    ('molmod', '1.4.5'),
+]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+# required because we're building a Python package using Intel compilers on top of Python built with GCC
+check_ldshared = True
+
+runtest = "export MATPLOTLIBRC=$PWD; echo 'backend: agg' > $MATPLOTLIBRC/matplotlibrc; "
+runtest += "python setup.py build_ext -i; nosetests -v"
+
+moduleclass = 'chem'

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -317,6 +317,10 @@ class EasyConfigTest(TestCase):
             'h5py': [
                 (r'2\.', [r'yaff-1\.6\.0-'], [r'LAMMPS-29Oct20-']),
             ],
+            # LAMMPS requires Eigen 3.3.9
+            'Eigen': [
+                (r'3\.3\.9', [r'LAMMPS-29Oct20-']),
+            ],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:
             for key in list(dep_vars):

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -315,11 +315,7 @@ class EasyConfigTest(TestCase):
                       'NGSpeciesID-0.1.1.1-'])],
             # yaff requires h5py 2.x.x. LAMMPS depends on yaff.
             'h5py': [
-                (r'2\.', [r'yaff-1\.6\.0-'], [r'LAMMPS-29Oct20-']),
-            ],
-            # LAMMPS requires Eigen 3.3.9
-            'Eigen': [
-                (r'3\.3\.9', [r'LAMMPS-29Oct20-']),
+                (r'2\.', [r'yaff-1\.6\.0-', r'LAMMPS-29Oct20-']),
             ],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -313,6 +313,10 @@ class EasyConfigTest(TestCase):
             # decona 0.1.2 and NGSpeciesID 0.1.1.1 depend on medaka 1.1.3
             'Pysam': [('0.16.0.1;', ['medaka-1.2.[0]-', 'medaka-1.1.[13]-', 'decona-0.1.2-',
                       'NGSpeciesID-0.1.1.1-'])],
+            # yaff requires h5py 2.x.x
+            'h5py': [
+                (r'2\.', [r'yaff-1\.6\.0-']),
+            ],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:
             for key in list(dep_vars):

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -315,7 +315,7 @@ class EasyConfigTest(TestCase):
                       'NGSpeciesID-0.1.1.1-'])],
             # yaff requires h5py 2.x.x. LAMMPS depends on yaff.
             'h5py': [
-                (r'2\.', [r'yaff-1\.6\.0-', r'LAMMPS-29Oct20-']),
+                (r'2\.10\.0', [r'yaff-1\.6\.0-', r'LAMMPS-29Oct20-']),
             ],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -313,9 +313,9 @@ class EasyConfigTest(TestCase):
             # decona 0.1.2 and NGSpeciesID 0.1.1.1 depend on medaka 1.1.3
             'Pysam': [('0.16.0.1;', ['medaka-1.2.[0]-', 'medaka-1.1.[13]-', 'decona-0.1.2-',
                       'NGSpeciesID-0.1.1.1-'])],
-            # yaff requires h5py 2.x.x
+            # yaff requires h5py 2.x.x. LAMMPS depends on yaff.
             'h5py': [
-                (r'2\.', [r'yaff-1\.6\.0-']),
+                (r'2\.', [r'yaff-1\.6\.0-'], [r'LAMMPS-29Oct20-']),
             ],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:

--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -313,10 +313,8 @@ class EasyConfigTest(TestCase):
             # decona 0.1.2 and NGSpeciesID 0.1.1.1 depend on medaka 1.1.3
             'Pysam': [('0.16.0.1;', ['medaka-1.2.[0]-', 'medaka-1.1.[13]-', 'decona-0.1.2-',
                       'NGSpeciesID-0.1.1.1-'])],
-            # yaff requires h5py 2.x.x. LAMMPS depends on yaff.
-            'h5py': [
-                (r'2\.10\.0', [r'yaff-1\.6\.0-', r'LAMMPS-29Oct20-']),
-            ],
+            # yaff requires h5py 2.10.0. LAMMPS depends on yaff.
+            'h5py': [(r'2\.10\.0', [r'yaff-1\.6\.0-', r'LAMMPS-29Oct2020-'])],
         }
         if dep in old_dep_versions and len(dep_vars) > 1:
             for key in list(dep_vars):


### PR DESCRIPTION
For ExCALIBUR and INC1129085 - `LAMMPS-29Oct2020-foss-2020b-kokkos.eb`

Please also see https://github.com/bear-rsg/easybuild-easyblocks/pull/85.

* [x] Assigned to reviewers (usually everyone in apps team)

Note: will not work with `srun`.

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

The `USER-SDPD` package has been added to `LAMMPS`.

`LAMMPS` gives `Eigen/3.3.8-GCCcore-10.2.0/include/Eigen/src/Core/products/Parallelizer.h:162:19: error: eigen_assert_exception is not a member of Eigen` when building with `Eigen/3.3.8-GCCcore-10.2.0`, so `Eigen 3.3.9` was used.

`ScaFaCoS` needs the addition of `configopts += 'FCFLAGS="$FCFLAGS -fallow-argument-mismatch" '` to work with `GCC 10`.

`yaff` doesn't build with `h5py/3.1.0-foss-2020b`, so `h5py 2.10.0` was used.

`LAMMPS-29Oct2020_VTK9.patch` is needed for `LAMMPS` to build with `VTK 9` (to avoid `LAMMPS/29Oct2020/foss-2020b-kokkos/lammps-stable_29Oct2020/src/USER-VTK/dump_vtk.cpp:1092:20: error: class vtkIntArray has no member named InsertNextTupleValue; did you mean InsertNextTuple?`). 

`VTK 8.2.0` has a different problem with `GCC 10`: `/binutils/2.35-GCCcore-10.2.0/bin/ld.gold: error: CMakeFiles/vtkexodusII.dir/src/ex_open_par.c.o: multiple definition of 'exodus_unused_symbol_dummy_1'`. This has been fixed in version 9.