### PR TITLE
p4est 2.3.2 2020a

### DIFF
--- a/easybuild/easyconfigs/p/p4est/p4est-2.3.2-foss-2020a.eb
+++ b/easybuild/easyconfigs/p/p4est/p4est-2.3.2-foss-2020a.eb
@@ -1,0 +1,43 @@
+easyblock = 'ConfigureMake'
+
+name = 'p4est'
+version = '2.3.2'
+
+homepage = 'https://www.p4est.org'
+description = """p4est is a C library to manage a collection (a forest) of multiple
+connected adaptive quadtrees or octrees in parallel."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://p4est.github.io/release',
+]
+sources = [
+    '%(name)s-%(version)s.tar.gz',
+]
+checksums = ['076df9e5578e0e7fcfbe12e1a0b080104001f8c986ab1d5a69ec2220050df8e6']
+
+builddependencies = [
+    ('Autotools', '20180311')
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('METIS', '5.1.0'),
+    ('Lua', '5.3.5')
+]
+
+configopts = '--enable-openmp --enable-mpi --with-metis '
+configopts += 'BLAS_LIBS=$EBROOTOPENBLAS/lib/libopenblas.so '
+configopts += 'LAPACK_LIBS=$EBROOTSCALAPACK/lib/libscalapack.a '
+
+runtest = 'check VERBOSE=1'
+
+sanity_check_paths = {
+    'files': ['bin/p4est_simple', 'bin/p4est_step1', 'bin/p4est_step2', 'bin/p4est_step3', 'bin/p4est_step4',
+              'lib/libp4est.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/p4est/p4est-2.3.2-iomkl-2020a.eb
+++ b/easybuild/easyconfigs/p/p4est/p4est-2.3.2-iomkl-2020a.eb
@@ -29,7 +29,6 @@ dependencies = [
 ]
 
 configopts = '--enable-openmp --enable-mpi --with-metis '
-# configopts += 'BLAS_LIBS=$EBROOTOPENBLAS/lib/libopenblas.so LAPACK_LIBS=$EBROOTSCALAPACK/lib/libscalapack.a '
 
 runtest = 'check VERBOSE=1'
 

--- a/easybuild/easyconfigs/p/p4est/p4est-2.3.2-iomkl-2020a.eb
+++ b/easybuild/easyconfigs/p/p4est/p4est-2.3.2-iomkl-2020a.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'p4est'
+version = '2.3.2'
+
+homepage = 'https://www.p4est.org'
+description = """p4est is a C library to manage a collection (a forest) of multiple
+connected adaptive quadtrees or octrees in parallel."""
+
+toolchain = {'name': 'iomkl', 'version': '2020a'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = [
+    'https://p4est.github.io/release',
+]
+sources = [
+    '%(name)s-%(version)s.tar.gz',
+]
+checksums = ['076df9e5578e0e7fcfbe12e1a0b080104001f8c986ab1d5a69ec2220050df8e6']
+
+builddependencies = [
+    ('Autotools', '20180311')
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('METIS', '5.1.0'),
+    ('Lua', '5.3.5')
+]
+
+configopts = '--enable-openmp --enable-mpi --with-metis '
+# configopts += 'BLAS_LIBS=$EBROOTOPENBLAS/lib/libopenblas.so LAPACK_LIBS=$EBROOTSCALAPACK/lib/libscalapack.a '
+
+runtest = 'check VERBOSE=1'
+
+sanity_check_paths = {
+    'files': ['bin/p4est_simple', 'bin/p4est_step1', 'bin/p4est_step2', 'bin/p4est_step3', 'bin/p4est_step4',
+              'lib/libp4est.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
For INC1138887 - `p4est-2.3.2-foss-2020a.eb p4est-2.3.2-iomkl-2020a.eb`

`p4est-2.3.2-iomkl-2020a.eb` automatically finds `mkl` versions of `BLAS` and `LAPACK`, so `BLAS_LIBS` and `LAPACK_LIBS` don't need to be set.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell