### PR TITLE
Add easyconfig for king-2.2.7-foss-2020b.eb

### DIFF
--- a/easybuild/easyconfigs/k/king/king-2.2.7-foss-2020b.eb
+++ b/easybuild/easyconfigs/k/king/king-2.2.7-foss-2020b.eb
@@ -17,7 +17,7 @@ checksums = ['486e7e94dde16d427f9d3fc99a33fa3f72f67e2f61b7264b4579111c9fb95be3']
 
 extract_sources = True
 
-install_cmd =  "mkdir -p %(installdir)s/bin && "
+install_cmd = "mkdir -p %(installdir)s/bin && "
 install_cmd += "g++ *.cpp -DWITH_OPENBLAS -DWITH_LAPACK -lopenblas -lm -lz -O2 -o king && "
 install_cmd += "mv king %(installdir)s/bin"
 

--- a/easybuild/easyconfigs/k/king/king-2.2.7-foss-2020b.eb
+++ b/easybuild/easyconfigs/k/king/king-2.2.7-foss-2020b.eb
@@ -1,0 +1,29 @@
+# Contribution from the R Pepper @ University of Birmingham
+
+easyblock = 'Binary'
+
+name = 'king'
+version = '2.2.7'
+
+homepage = 'https://www.kingrelatedness.com/manual.shtml'
+description = """KING is a toolset to explore genotype data from a genome-wide
+  association study (GWAS) or a sequencing project"""
+
+toolchain = {'name': 'foss', 'version': '2020b'}
+
+source_urls = ['https://www.kingrelatedness.com/executables/']
+sources = ['KING%scode.tar.gz' % version]
+checksums = ['486e7e94dde16d427f9d3fc99a33fa3f72f67e2f61b7264b4579111c9fb95be3']
+
+extract_sources = True
+
+install_cmd =  "mkdir -p %(installdir)s/bin && "
+install_cmd += "g++ *.cpp -DWITH_OPENBLAS -DWITH_LAPACK -lopenblas -lm -lz -O2 -o king && "
+install_cmd += "mv king %(installdir)s/bin"
+
+sanity_check_paths = {
+    'files': ['bin/king'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1140641 - `king-2.2.7-foss-2020b.eb`

There is an upstream easyconf for an older version, but it uses the binary. I've built with -O2 level optimisation as middle ground. I saw in the source that there were various `WITH_LAPACK`, and within those `WITH_OPENBLAS` macro checks which enable things like SVD and other linalg stuff that are otherwise disabled, so I enabled this and linked in OpenBLAS, and it seems to compile OK.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

