### PR TITLE
Muscle eb from upstream

### DIFF
--- a/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.1551-GCC-8.3.0.eb
+++ b/easybuild/easyconfigs/m/MUSCLE/MUSCLE-3.8.1551-GCC-8.3.0.eb
@@ -1,0 +1,30 @@
+easyblock = 'MakeCp'
+
+name = 'MUSCLE'
+version = "3.8.1551"
+
+homepage = 'https://drive5.com/muscle/'
+description = """MUSCLE is one of the best-performing multiple alignment programs
+ according to published benchmark tests, with accuracy and speed that are consistently
+ better than CLUSTALW. MUSCLE can align hundreds of sequences in seconds. Most users
+ learn everything they need to know about MUSCLE in a few minutes-only a handful of
+ command-line options are needed to perform common alignment tasks."""
+
+toolchain = {'name': 'GCC', 'version': '8.3.0'}
+
+source_urls = ['https://www.drive5.com/muscle/']
+sources = ['%(namelower)s_src_%(version)s.tar.gz']
+checksums = ['c70c552231cd3289f1bad51c9bd174804c18bb3adcf47f501afec7a68f9c482e']
+
+# use correct compiler flags +
+# don't use -static when linking, since that implies requiring glibc-static to be installed
+buildopts = 'CFLAGS="$CXXFLAGS" LDLIBS="-lm"'
+
+files_to_copy = [(["muscle"], 'bin')]
+
+sanity_check_paths = {
+    'files': ["bin/%(namelower)s"],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1137144 - `MUSCLE-3.8.1551-GCC-8.3.0.eb`

(Easyconf file from upstream)

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] Ubuntu20 VM
