### PR TITLE
iterativeWGCNA

### DIFF
--- a/easybuild/easyconfigs/i/iterativeWGCNA/iterativeWGCNA-1.1.6-foss-2020a-Python-3.8.2-R-4.0.0.eb
+++ b/easybuild/easyconfigs/i/iterativeWGCNA/iterativeWGCNA-1.1.6-foss-2020a-Python-3.8.2-R-4.0.0.eb
@@ -23,6 +23,7 @@ dependencies = [
 
 source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
+checksums = ['1ee490a1b7a0e1164fda08d38053a17f974f82f0237b8c2864bd12a28f3a8efb']
 
 download_dep_fail = True
 sanity_pip_check = True

--- a/easybuild/easyconfigs/i/iterativeWGCNA/iterativeWGCNA-1.1.6-foss-2020a-Python-3.8.2-R-4.0.0.eb
+++ b/easybuild/easyconfigs/i/iterativeWGCNA/iterativeWGCNA-1.1.6-foss-2020a-Python-3.8.2-R-4.0.0.eb
@@ -1,0 +1,40 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'PythonPackage'
+
+name = 'iterativeWGCNA'
+version = '1.1.6'
+_pysuffix = '-Python-%(pyver)s'
+_rsuffix = '-R-%(rver)s'
+versionsuffix = '%s%s' % (_pysuffix, _rsuffix)
+
+homepage = "https://github.com/cstoeckert/iterativeWGCNA"
+description = """Extension of the WGCNA program to improve the eigengene similarity of modules and increase the overall
+ number of genes in modules."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('R', '4.0.0'),
+    ('WGCNA', '1.70-3', _rsuffix),
+    ('rpy2', '3.3.6', _pysuffix),
+    ('matplotlib', '3.2.1', _pysuffix),
+]
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+download_dep_fail = True
+sanity_pip_check = True
+use_pip = True
+
+options = {'modulename': '%(name)s'}
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s', 'bin/%(name)s_merge'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s']
+}
+
+sanity_check_commands = ['%(name)s --help']
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/rpy2/rpy2-3.3.6-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/r/rpy2/rpy2-3.3.6-foss-2020a-Python-3.8.2.eb
@@ -31,9 +31,6 @@ exts_list = [
     ('tzlocal', '2.1', {
         'checksums': ['643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44'],
     }),
-    ('cffi', '1.14.5', {
-        'checksums': ['fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c'],
-    }),
     (name, version, {
         'checksums': ['ce063f3286e717b3914728ad23ec7db0a0f117ba3ade5ada8a250700779f6e77'],
     }),

--- a/easybuild/easyconfigs/r/rpy2/rpy2-3.3.6-foss-2020a-Python-3.8.2.eb
+++ b/easybuild/easyconfigs/r/rpy2/rpy2-3.3.6-foss-2020a-Python-3.8.2.eb
@@ -1,0 +1,56 @@
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+
+easyblock = 'PythonBundle'
+
+name = 'rpy2'
+version = '3.3.6'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://rpy2.bitbucket.io/'
+description = """rpy2 is an interface to R running embedded in a Python process."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+dependencies = [
+    ('Python', '3.8.2'),
+    ('R', '4.0.0'),
+    ('IPython', '7.13.0', versionsuffix),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_default_options = {'source_urls': [PYPI_SOURCE]}
+
+exts_list = [
+    ('simplegeneric', '0.8.1', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'checksums': ['dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173'],
+    }),
+    ('tzlocal', '2.1', {
+        'checksums': ['643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44'],
+    }),
+    ('cffi', '1.14.5', {
+        'checksums': ['fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c'],
+    }),
+    (name, version, {
+        'checksums': ['ce063f3286e717b3914728ad23ec7db0a0f117ba3ade5ada8a250700779f6e77'],
+    }),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    "pytest --pyargs rpy2 "
+    # Disable tests which require X11 present othewise it crashes with
+    # "unable to open connection to X11 display" error
+    "--ignore lib/python%(pyshortver)s/site-packages/rpy2/tests/ipython/test_rmagic.py "
+    "--ignore lib/python%(pyshortver)s/site-packages/rpy2/tests/robjects/lib/test_grdevices.py "
+    "--ignore lib/python%(pyshortver)s/site-packages/rpy2/tests/robjects/lib/test_grid.py "
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/w/WGCNA/WGCNA-1.70-3-foss-2020a-R-4.0.0.eb
+++ b/easybuild/easyconfigs/w/WGCNA/WGCNA-1.70-3-foss-2020a-R-4.0.0.eb
@@ -1,0 +1,48 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Bundle'
+
+name = 'WGCNA'
+version = '1.70-3'
+versionsuffix = '-R-%(rver)s'
+
+homepage = "https://cran.r-project.org/package=WGCNA"
+description = """Functions necessary to perform Weighted Correlation Network Analysis on high-dimensional data as
+ originally described in Horvath and Zhang (2005) <doi:10.2202/1544-6115.1128> and Langfelder and Horvath (2008)
+ <doi:10.1186/1471-2105-9-559>. Includes functions for rudimentary data cleaning, construction of correlation networks,
+ module identification, summarization, and relating of variables and modules to sample traits. Also includes a number of
+ utility functions for data manipulation and visualization."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+dependencies = [
+    ('R', '4.0.0'),
+    ('R-bundle-Bioconductor', '3.11', versionsuffix)
+]
+
+exts_defaultclass = 'RPackage'
+exts_filter = ("R -q --no-save", "library(%(ext_name)s)")
+exts_default_options = {
+    'source_urls': [
+        'https://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
+        'https://cran.r-project.org/src/contrib/',  # current version of packages
+        'https://cran.freestatistics.org/src/contrib',  # mirror alternative for current packages
+    ],
+    'source_tmpl': '%(name)s_%(version)s.tar.gz',
+}
+
+
+# Order is important!
+exts_list = [
+    (name, version, {
+        'checksums': ['b9843b839728183af6b746f239e9519d438b294613362b556002acdb8522cbd4'],
+    }),
+]
+
+modextrapaths = {'R_LIBS': ''}
+
+sanity_check_paths = {
+    'files': ['WGCNA/R/WGCNA'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1140587 - `iterativeWGCNA-1.1.6-foss-2020a-Python-3.8.2-R-4.0.0.eb`

Note: Ubuntu build of `rpy2` fails when using Singularity.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
* [ ] Ubuntu20 VM


`test_grid.py` added to list of ignored tests for `rpy2`. All tests pass when run separately after the installation.