### PR TITLE
update tc conf to use new EPS lic srv

### DIFF
--- a/easybuild/easyconfigs/t/Thermo-Calc/Thermo-Calc-2020a-foss-2019b.eb
+++ b/easybuild/easyconfigs/t/Thermo-Calc/Thermo-Calc-2020a-foss-2019b.eb
@@ -27,7 +27,7 @@ local_command_list = [
     "./Thermo-Calc*.run",
     "--mode unattended",
     "--enable-components thermo,databases,tcapi,tq",
-    "--license_server met-prism2-lm2.bham.ac.uk",
+    "--license_server met-tc.bham.ac.uk",
     "--installation_mode custom",
     "--prefix %(builddir)s",
 ]
@@ -46,7 +46,7 @@ postinstallcmds = [
 modextravars = {
     'TC20A_HOME': '%(installdir)s',
     'TCPATH': '%(installdir)s',
-    'LSHOST': 'met-prism2-lm2.bham.ac.uk'
+    'LSHOST': 'met-tc.bham.ac.uk'
 }
 
 modextrapaths = {


### PR DESCRIPTION
For CHG68270 - `Thermo-Calc-2020a-foss-2019b.eb`

Do not rebuild on live. Just edit the following files, replacing `met-prism2-lm2.bham.ac.uk` with `met-tc.bham.ac.uk`

/rds/bear-apps/2019b/EL8-cas/modules/all/Thermo-Calc/2020a-foss-2019b
/rds/bear-apps/2019b/EL8-has/modules/all/Thermo-Calc/2020a-foss-2019b