### PR TITLE
LS-DYNA fix PATH

### DIFF
--- a/easybuild/easyconfigs/l/LS-DYNA/LS-DYNA-11.2.2-iccifort-2020.4.304.eb
+++ b/easybuild/easyconfigs/l/LS-DYNA/LS-DYNA-11.2.2-iccifort-2020.4.304.eb
@@ -41,4 +41,6 @@ checksums = [
 
 dependencies = [('impi', '2019.12.320')]
 
+modextrapaths = {'PATH': ['']}
+
 moduleclass = 'cae'


### PR DESCRIPTION
For INC1134435 - `LS-DYNA-11.2.2-iccifort-2020.4.304.eb --module-only`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell