### PR TITLE
Add BWA 2020a version

### DIFF
--- a/easybuild/easyconfigs/b/BWA/BWA-0.7.17-foss-2020a.eb
+++ b/easybuild/easyconfigs/b/BWA/BWA-0.7.17-foss-2020a.eb
@@ -1,0 +1,34 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+#
+# Version >= 0.7.15
+# Author: Adam Huffman, Big Data Institute, University of Oxford
+#
+# Note that upstream development is mainly at: https://github.com/lh3/bwa
+##
+
+name = 'BWA'
+version = '0.7.17'
+
+homepage = 'http://bio-bwa.sourceforge.net/'
+description = """Burrows-Wheeler Aligner (BWA) is an efficient program that aligns
+ relatively short nucleotide sequences against a long reference sequence such as the human genome."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/lh3/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['980b9591b61c60042c4a39b9e31ccaad8d17ff179d44d347997825da3fdf47fd']
+
+dependencies = [('zlib', '1.2.11')]
+
+moduleclass = 'bio'


### PR DESCRIPTION
For deena mega ticket INC1145573 - `BWA-0.7.17-foss-2020a.eb`. Copy of previous with updated versions

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

Add these if requested:
* [ ] EL8-power9
* [ ] Ubuntu20 VM
