### PR TITLE
Port MERLIN easyconfig to 9.3.0

### DIFF
--- a/easybuild/easyconfigs/m/MERLIN/MERLIN-1.1.2-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/m/MERLIN/MERLIN-1.1.2-GCCcore-9.3.0.eb
@@ -1,0 +1,38 @@
+easyblock = 'ConfigureMake'
+
+name = 'MERLIN'
+version = '1.1.2'
+
+homepage = "https://csg.sph.umich.edu/abecasis/MERLIN/index.html"
+description = """MERLIN uses sparse trees to represent gene flow in pedigrees and is one of the fastest pedigree
+ analysis packages around."""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = ['https://csg.sph.umich.edu/abecasis/MERLIN/download/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['%(name)s-%(version)s_makefile.patch']
+checksums = [
+    'aa3c087b1c717209389705bf2ace4c24884575014a561dff250c0be93fe1e411',  # merlin-1.1.2.tar.gz
+    'fd7456a33fb41b0b216c92970a0ec87236a6ee1dbfc3f9ef4f2a6ba60d3fb74b',  # MERLIN-1.1.2_makefile.patch
+]
+
+builddependencies = [('binutils', '2.34')]
+
+dependencies = [('zlib', '1.2.11')]
+
+skipsteps = ['configure']
+
+buildopts = 'all'
+
+installopts = 'INSTALLDIR=%(installdir)s/bin '
+
+sanity_check_paths = {
+    'files': ['bin/%s' % _x for _x in ['hapmapConverter', 'merlin', 'merlin-offline', 'merlin-regress', 'minx',
+                                       'minx-offline', 'pedmerge', 'pedstats', 'pedwipe']],
+    'dirs': [],
+}
+
+sanity_check_commands = ['pedmerge --help']
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MERLIN/MERLIN-1.1.2_makefile.patch
+++ b/easybuild/easyconfigs/m/MERLIN/MERLIN-1.1.2_makefile.patch
@@ -1,0 +1,11 @@
+MERLIN unpacks a .tar.gz during install. Patch the build to fix the source that is unpacked.
+--- Makefile.orig	2020-11-30 15:43:34.746222000 +0000
++++ Makefile	2020-11-30 18:48:56.852420116 +0000
+@@ -180,6 +180,7 @@
+ 
+ $(PEDSTATS) : pedstats-$(PSVERSION).tar.gz
+ 	gunzip -c pedstats-$(PSVERSION).tar.gz | tar -xf - 
++	sed -i "s/'G' + 128, 'R' + 128, 'A' + 128/(char) ('G' + 128), (char) ('R' + 128), (char) ('A' + 128)/g" pedstats-$(PSVERSION)/janpdf/PDF.cpp
+ 	cd pedstats-$(PSVERSION) ; $(MAKE) executables/pedstats
+ 	cp pedstats-$(PSVERSION)/executables/pedstats executables
+ 	rm -rf pedstats-$(PSVERSION)


### PR DESCRIPTION
For INC1145573 - `MERLIN-1.1.2-GCCcore-9.3.0.eb`
Port of previous easyconfig from 2019b as part of unifying all Bio MSc stuff under 2020a so can be used together.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
