### PR TITLE
Add PyCharm 2021.2

### DIFF
--- a/easybuild/easyconfigs/p/PyCharm/PyCharm-2021.2.eb
+++ b/easybuild/easyconfigs/p/PyCharm/PyCharm-2021.2.eb
@@ -1,0 +1,20 @@
+easyblock = 'Tarball'
+
+name = 'PyCharm'
+version = "2021.2"
+
+homepage = 'https://www.jetbrains.com/pycharm/'
+description = """PyCharm Community Edition: Python IDE for Professional Developers"""
+
+toolchain = SYSTEM
+
+source_urls = ['https://download-cdn.jetbrains.com/python/']
+sources = ['pycharm-community-%(version)s.tar.gz']
+checksums = ['bd861c446856b8b837542dffa1dd6607dcf5118a102a2461486714f44059b41c']
+
+sanity_check_paths = {
+    'files': ["bin/pycharm.sh"],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
For INC1152362 - `PyCharm-2021.2.eb`
Updated from previous upstream versions, new download URL. For use primarily as a Portal app.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-cascadelake
* [ ] EL8-haswell

