### PR TITLE
BNC Ntrip client / Qt 4.8.7

### DIFF
--- a/easybuild/easyconfigs/b/BNC/BNC-2.12.18-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/b/BNC/BNC-2.12.18-GCCcore-10.2.0.eb
@@ -14,6 +14,8 @@ source_urls = ['https://igs.bkg.bund.de/root_ftp/NTRIP/software']
 sources = ['%(namelower)s-%(version)s-source.zip']
 checksums = ['1d4cb84a09ee67fe1d1209c4730a3a5230de954305d20e1f68e6e97435abe9ad']
 
+builddependencies = [('binutils', '2.35')]
+
 dependencies = [
     ('Qt', '4.8.7', '', True),
 ]

--- a/easybuild/easyconfigs/b/BNC/BNC-2.12.18-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/b/BNC/BNC-2.12.18-GCCcore-10.2.0.eb
@@ -1,0 +1,34 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'BNC'
+version = '2.12.18'
+
+homepage = "https://software.rtcm-ntrip.org/export/HEAD/ntrip/trunk/BNC/src/bnchelp.html"
+description = """BKG Ntrip Client (BNC) is a toolkit for retrieving, decoding, converting and processing real-time
+ GNSS data streams"""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+source_urls = ['https://igs.bkg.bund.de/root_ftp/NTRIP/software']
+sources = ['%(namelower)s-%(version)s-source.zip']
+checksums = ['1d4cb84a09ee67fe1d1209c4730a3a5230de954305d20e1f68e6e97435abe9ad']
+
+dependencies = [
+    ('Qt', '4.8.7', '', True),
+]
+
+start_dir = '%(name)s_%(version)s'
+
+build_cmd = 'qmake bnc.pro && make'
+
+files_to_copy = [(['bnc'], 'bin'), 'Example_Configs', 'newmat', 'qwt', 'qwtpolar', 'src', 'ChangeLog.txt']
+
+sanity_check_paths = {
+    'files': ['bin/bnc'],
+    'dirs': ['qwt'],
+}
+
+sanity_check_commands = ['bnc --help']
+
+moduleclass = 'geo'

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7.eb
@@ -1,0 +1,37 @@
+name = 'Qt'
+version = '4.8.7'
+
+homepage = 'https://qt.io/'
+description = "Qt is a comprehensive cross-platform C++ application framework."
+
+toolchain = SYSTEM
+# Setting cstd here doesn't work with the SYSTEM toolchain for some reason,
+# so CFLAGS and CXXFLAGS have been set in preconfigopts
+# toolchainopts = {'cstd': 'gnu++98'}
+
+source_urls = [
+    'https://download.qt.io/official_releases/qt/%(version_major_minor)s/%(version)s/',
+    'https://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/'
+]
+sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz']
+patches = [
+    'Qt-%(version)s_phonon-export.patch',
+    'Qt-%(version)s_no-ssl3.patch',
+    'Qt-%(version)s_openssl_1.1.patch',
+]
+checksums = [
+    'e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0',  # qt-everywhere-opensource-src-4.8.7.tar.gz
+    '3853c87c33695bfa57e207ffb0d94cb2565aa462eccdf44d2b2804fd44ecbad6',  # Qt-4.8.7_phonon-export.patch
+    '744514a2c7d1fb8c127ea91da7655911c13f72499127e0cc1bceba0c2551a0e2',  # Qt-4.8.7_no-ssl3.patch
+    '754eab951fa63abdb04c1530d386363a45471a2759a4253f5b014c1f0f7a8e47',  # Qt-4.8.7_openssl_1.1.patch
+    '0bded2c1a7906ce1435c202eb6c96da66f52c8567928ea5e70cf8b704fc4b226',  # Qt-4.8.7_system-toolchain-gnu++98.patch
+]
+
+platform = 'linux-g++-64'
+
+preconfigopts = "CFLAGS='-std=gnu++98' CXXFLAGS='-std=gnu++98'"
+
+configopts = '-shared -webkit -opensource -no-pch'
+configopts += ' -no-sql-mysql -no-sql-sqlite'
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.7.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.7.eb
@@ -24,7 +24,6 @@ checksums = [
     '3853c87c33695bfa57e207ffb0d94cb2565aa462eccdf44d2b2804fd44ecbad6',  # Qt-4.8.7_phonon-export.patch
     '744514a2c7d1fb8c127ea91da7655911c13f72499127e0cc1bceba0c2551a0e2',  # Qt-4.8.7_no-ssl3.patch
     '754eab951fa63abdb04c1530d386363a45471a2759a4253f5b014c1f0f7a8e47',  # Qt-4.8.7_openssl_1.1.patch
-    '0bded2c1a7906ce1435c202eb6c96da66f52c8567928ea5e70cf8b704fc4b226',  # Qt-4.8.7_system-toolchain-gnu++98.patch
 ]
 
 platform = 'linux-g++-64'


### PR DESCRIPTION
For DASP - `BNC-2.12.18-GCCcore-10.2.0.eb`

`SYSTEM` toolchain used for `Qt 4.8.7` to avoid problems with GCC version >= 9.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-cascadelake
* [x] EL8-haswell
