### PR TITLE
PyTorch 1.10, from upstream

### DIFF
--- a/easybuild/easyconfigs/e/expecttest/expecttest-0.1.3-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/e/expecttest/expecttest-0.1.3-GCCcore-10.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'expecttest'
+version = '0.1.3'
+
+homepage = "https://github.com/ezyang/expecttest"
+description = """This library implements expect tests (also known as "golden" tests). Expect tests are a method of
+ writing tests where instead of hard-coding the expected output of a test, you run the test to get the output, and
+ the test framework automatically populates the expected output. If the output of the test changes, you can rerun
+ the test with the environment variable EXPECTTEST_ACCEPT=1 to automatically update the expected output."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+sources = [SOURCE_TAR_GZ]
+checksums = ['83057695811d94128aed13ed094a070db90e0a92ea40071f8ee073cbab57149a']
+
+builddependencies = [('binutils', '2.36.1')]
+
+dependencies = [('Python', '3.9.5')]
+
+use_pip = True
+download_dep_fail = True
+sanity_pip_check = True
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0-foss-2021a-CUDA-11.3.1.eb
@@ -1,0 +1,128 @@
+name = 'PyTorch'
+version = '1.10.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/pytorch',
+        'repo_name': 'pytorch',
+        'tag': 'v%(version)s',
+        'recursive': True,
+    },
+}]
+patches = [
+    'PyTorch-1.7.0_avoid-nan-in-test-torch.patch',
+    'PyTorch-1.7.0_disable-dev-shm-test.patch',
+    'PyTorch-1.7.1_correctly-pass-jit_opt_level.patch',
+    'PyTorch-1.8.1_dont-use-gpu-ccc-in-test.patch',
+    'PyTorch-1.8.1_increase-distributed-test-timeout.patch',
+    'PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch',
+    'PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch',
+    'PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch',
+    'PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch',
+    'PyTorch-1.10.0_fix-test-cond-cpu.patch',
+    'PyTorch-1.10.0_fix-vnni-detection.patch',
+    'PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch',
+    'PyTorch-1.10.0_skip_failing_ops_tests.patch',
+    'PyTorch-1.10.0_skip_nan_tests_openblas.patch',
+    'PyTorch-1.10.0_skip_cmake_rpath.patch',
+]
+checksums = [
+    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch
+    '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a',  # PyTorch-1.7.0_disable-dev-shm-test.patch
+    # PyTorch-1.7.1_correctly-pass-jit_opt_level.patch
+    'd4d967d47f8a6172fcbf57f0a61835482968850967c4fdb01108b720696a988d',
+    '89ac7a8e9e7df2e64cf8404fe3a279f5e9b759fee41c9de3aaff9c22f385c2c6',  # PyTorch-1.8.1_dont-use-gpu-ccc-in-test.patch
+    # PyTorch-1.8.1_increase-distributed-test-timeout.patch
+    '7a6e512274f0b8673f4f207a5bc53387d88be7e79833f42d20365668b2118071',
+    # PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch
+    'ff573660913ce055e24cfd194ce747ba5685091c631cfd443eae2a99d56b57ea',
+    # PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch
+    '313dca681f45ce3bc7c4557fdcdcbe0b77216d2c708fa30a2ec0e22c44876707',
+    # PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch
+    '426c9ead1a74b656748d4c8bf8afd4303d8b9f2394ad22b21a845d07c8ca1d12',
+    # PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch
+    '67152215e4530a9b1d7349fb20864445fd815288f04ab9e96e45c73b2d87827a',
+    # PyTorch-1.10.0_fix-test-cond-cpu.patch
+    '51f83f5d5ef69656ef35b73f17e0671e70113798421be11ea4c7b56ffcc4da03',
+    # PyTorch-1.10.0_fix-vnni-detection.patch
+    '1f3664c0febfa2a3fc4c0cd3bae185f289716ac0b6c3d7e8fa1cee19ba62b7cc',
+    # PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch
+    'e65afb01786f7f030ccb5faada1eb474bb0c418bcadcf1baaa71a4fa2f3f4240',
+    # PyTorch-1.10.0_skip_failing_ops_tests.patch
+    '399af94ffcef4a6db5226552c46f11e9b0f0f371b2d7924b9e5764d2281581ab',
+    # PyTorch-1.10.0_skip_nan_tests_openblas.patch
+    '7d3f83e3056d9e47a460790313238f28708beb596cafaa7ae55e374d368bbedf',
+    # PyTorch-1.10.0_skip_cmake_rpath.patch
+    'ac05943bb205623f91ef140aa00869efc5fe844184bd666bebf5405808610448',
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+    ('hypothesis', '6.13.1'),
+]
+
+dependencies = [
+    ('CUDA', '11.3.1', '', True),
+    ('Ninja', '1.10.2'),  # Required for JIT compilation of C++ extensions
+    ('Python', '3.9.5'),
+    ('protobuf', '3.17.3'),
+    ('protobuf-python', '3.17.3'),
+    ('pybind11', '2.6.2'),
+    ('SciPy-bundle', '2021.05'),
+    ('typing-extensions', '3.10.0.0'),
+    ('PyYAML', '5.4.1'),
+    ('MPFR', '4.1.0'),
+    ('GMP', '6.2.1'),
+    ('numactl', '2.0.14'),
+    ('FFmpeg', '4.3.2'),
+    ('Pillow', '8.2.0'),
+    ('cuDNN', '8.2.1.32', '-CUDA-%(cudaver)s', True),
+    ('magma', '2.6.1', '-CUDA-%(cudaver)s'),
+    ('NCCL', '2.10.3', '-CUDA-%(cudaver)s'),
+    ('expecttest', '0.1.3'),
+]
+
+# default CUDA compute capabilities to use (override via --cuda-compute-capabilities)
+cuda_compute_capabilities = ['3.5', '3.7', '5.2', '6.0', '6.1', '7.0', '7.2', '7.5', '8.0', '8.6']
+
+custom_opts = ["USE_CUPTI_SO=1"]
+
+excluded_tests = {
+    '': [
+        # Bad tests: https://github.com/pytorch/pytorch/issues/60260
+        'distributed/elastic/utils/distributed_test',
+        'distributed/elastic/multiprocessing/api_test',
+        # These tests fail on A10s at the very least, they time out forever no matter how long the timeout is.
+        # Possibly related to NCCL 2.8.3: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-8-3.html
+        # 'distributed/test_distributed_fork',
+        'distributed/test_distributed_spawn',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        'test_optim',
+        # Test from this suite timeout often. The process group backend is deprecated anyway
+        # 'distributed/rpc/test_process_group_agent',
+    ]
+}
+
+runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
+
+# The readelf sanity check can be taken out once the TestRPATH test from https://github.com/pytorch/pytorch/pull/68912
+# is accepted, since it is then checked as part of the PyTorch test suite
+local_libcaffe2 = "$EBROOTPYTORCH/lib/python%%(pyshortver)s/site-packages/torch/lib/libcaffe2_nvrtc.%s" % SHLIB_EXT
+sanity_check_commands = [
+    "python -c 'import caffe2.python'",
+    "readelf -d %s | egrep 'RPATH|RUNPATH' | grep -v stubs" % local_libcaffe2,
+]
+tests = ['PyTorch-check-cpp-extension.py']
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0-foss-2021a.eb
@@ -1,0 +1,112 @@
+name = 'PyTorch'
+version = '1.10.0'
+
+homepage = 'https://pytorch.org/'
+description = """Tensors and Dynamic neural networks in Python with strong GPU acceleration.
+PyTorch is a deep learning framework that puts Python first."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+sources = [{
+    'filename': '%(name)s-%(version)s.tar.gz',
+    'git_config': {
+        'url': 'https://github.com/pytorch',
+        'repo_name': 'pytorch',
+        'tag': 'v%(version)s',
+        'recursive': True,
+    },
+}]
+patches = [
+    'PyTorch-1.7.0_avoid-nan-in-test-torch.patch',
+    'PyTorch-1.7.0_disable-dev-shm-test.patch',
+    'PyTorch-1.7.1_correctly-pass-jit_opt_level.patch',
+    'PyTorch-1.8.1_increase-distributed-test-timeout.patch',
+    'PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch',
+    'PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch',
+    'PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch',
+    'PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch',
+    'PyTorch-1.10.0_fix-test-cond-cpu.patch',
+    'PyTorch-1.10.0_fix-vnni-detection.patch',
+    'PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch',
+    'PyTorch-1.10.0_skip_failing_ops_tests.patch',
+    'PyTorch-1.10.0_skip_nan_tests_openblas.patch',
+]
+checksums = [
+    None,  # can't add proper SHA256 checksum, because source tarball is created locally after recursive 'git clone'
+    'b899aa94d9e60f11ee75a706563312ccefa9cf432756c470caa8e623991c8f18',  # PyTorch-1.7.0_avoid-nan-in-test-torch.patch
+    '622cb1eaeadc06e13128a862d9946bcc1f1edd3d02b259c56a9aecc4d5406b8a',  # PyTorch-1.7.0_disable-dev-shm-test.patch
+    # PyTorch-1.7.1_correctly-pass-jit_opt_level.patch
+    'd4d967d47f8a6172fcbf57f0a61835482968850967c4fdb01108b720696a988d',
+    # PyTorch-1.8.1_increase-distributed-test-timeout.patch
+    '7a6e512274f0b8673f4f207a5bc53387d88be7e79833f42d20365668b2118071',
+    # PyTorch-1.9.0_limit-world-size-for-zero-redundancy-opt-test.patch
+    'ff573660913ce055e24cfd194ce747ba5685091c631cfd443eae2a99d56b57ea',
+    # PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch
+    '313dca681f45ce3bc7c4557fdcdcbe0b77216d2c708fa30a2ec0e22c44876707',
+    # PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch
+    '426c9ead1a74b656748d4c8bf8afd4303d8b9f2394ad22b21a845d07c8ca1d12',
+    # PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch
+    '67152215e4530a9b1d7349fb20864445fd815288f04ab9e96e45c73b2d87827a',
+    # PyTorch-1.10.0_fix-test-cond-cpu.patch
+    '51f83f5d5ef69656ef35b73f17e0671e70113798421be11ea4c7b56ffcc4da03',
+    # PyTorch-1.10.0_fix-vnni-detection.patch
+    '1f3664c0febfa2a3fc4c0cd3bae185f289716ac0b6c3d7e8fa1cee19ba62b7cc',
+    # PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch
+    'e65afb01786f7f030ccb5faada1eb474bb0c418bcadcf1baaa71a4fa2f3f4240',
+    # PyTorch-1.10.0_skip_failing_ops_tests.patch
+    '399af94ffcef4a6db5226552c46f11e9b0f0f371b2d7924b9e5764d2281581ab',
+    # PyTorch-1.10.0_skip_nan_tests_openblas.patch
+    '7d3f83e3056d9e47a460790313238f28708beb596cafaa7ae55e374d368bbedf',
+]
+
+osdependencies = [OS_PKG_IBVERBS_DEV]
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+    ('hypothesis', '6.13.1'),
+]
+
+dependencies = [
+    ('Ninja', '1.10.2'),  # Required for JIT compilation of C++ extensions
+    ('Python', '3.9.5'),
+    ('protobuf', '3.17.3'),
+    ('protobuf-python', '3.17.3'),
+    ('pybind11', '2.6.2'),
+    ('SciPy-bundle', '2021.05'),
+    ('typing-extensions', '3.10.0.0'),
+    ('PyYAML', '5.4.1'),
+    ('MPFR', '4.1.0'),
+    ('GMP', '6.2.1'),
+    ('numactl', '2.0.14'),
+    ('FFmpeg', '4.3.2'),
+    ('Pillow', '8.2.0'),
+    ('expecttest', '0.1.3'),
+]
+
+# default CUDA compute capabilities to use (override via --cuda-compute-capabilities)
+cuda_compute_capabilities = ['3.5', '3.7', '5.2', '6.0', '6.1', '7.0', '7.2', '7.5', '8.0', '8.6']
+
+custom_opts = ["USE_CUPTI_SO=1"]
+
+excluded_tests = {
+    '': [
+        # Bad tests: https://github.com/pytorch/pytorch/issues/60260
+        'distributed/elastic/utils/distributed_test',
+        'distributed/elastic/multiprocessing/api_test',
+        # These tests fail on A10s at the very least, they time out forever no matter how long the timeout is.
+        # Possibly related to NCCL 2.8.3: https://docs.nvidia.com/deeplearning/nccl/release-notes/rel_2-8-3.html
+        # 'distributed/test_distributed_fork',
+        'distributed/test_distributed_spawn',
+        # Fails on A10s: https://github.com/pytorch/pytorch/issues/63079
+        'test_optim',
+        # Test from this suite timeout often. The process group backend is deprecated anyway
+        # 'distributed/rpc/test_process_group_agent',
+    ]
+}
+
+runtest = 'cd test && PYTHONUNBUFFERED=1 %(python)s run_test.py --continue-through-error  --verbose %(excluded_tests)s'
+
+sanity_check_commands = ["python -c 'import caffe2.python'"]
+tests = ['PyTorch-check-cpp-extension.py']
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-alias-violation-in-bitwise-ops.patch
@@ -1,0 +1,31 @@
+A reinterpret_cast to an unrelated type is undefined behavior.
+This causes real issues due to misoptimizations on at least GCC 10.2 on POWER
+See https://github.com/pytorch/pytorch/issues/58031
+
+Author: Alexander Grund (TU Dresden)
+
+Adapted for PT-1.10, where this is now in vec_base.h and templated
+
+diff --git a/aten/src/ATen/cpu/vec/vec_base.h b/aten/src/ATen/cpu/vec/vec_base.h
+index 697996ab8e..1663ae239a 100644
+--- a/aten/src/ATen/cpu/vec/vec_base.h
++++ b/aten/src/ATen/cpu/vec/vec_base.h
+@@ -701,12 +701,14 @@ inline Vectorized<T> operator^(const Vectorized<T>& a, const Vectorized<T>& b) {
+ 
+ template<class T, typename Op>
+ static inline Vectorized<T> bitwise_binary_op(const Vectorized<T> &a, const Vectorized<T> &b, Op op) {
+-  static constexpr uint32_t element_no = VECTOR_WIDTH / sizeof(intmax_t);
++  constexpr uint32_t element_no = VECTOR_WIDTH / sizeof(intmax_t);
++  __at_align__ intmax_t buffer_a[element_no];
++  __at_align__ intmax_t buffer_b[element_no];
+   __at_align__ intmax_t buffer[element_no];
+-  const intmax_t *a_ptr = reinterpret_cast<const intmax_t*>((const T*) a);
+-  const intmax_t *b_ptr = reinterpret_cast<const intmax_t*>((const T*) b);
++  a.store(buffer_a);
++  b.store(buffer_b);
+   for (uint32_t i = 0U; i < element_no; ++ i) {
+-    buffer[i] = op(a_ptr[i], b_ptr[i]);
++    buffer[i] = op(buffer_a[i], buffer_b[i]);
+   }
+   return Vectorized<T>::loadu(buffer);
+ }

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-faulty-asserts-and-skip-test.patch
@@ -1,0 +1,188 @@
+From: Alexander Grund <alexander.grund@tu-dresden.de>
+Date: Tue, 18 May 2021 15:08:41 +0200
+Subject: [PATCH 1/2] Fix usage of TORCH_INTERNAL_ASSERT with message
+
+Using only a string as the argument for TORCH_INTERNAL_ASSERT will never
+trigger a failure as a string is always a truethy value.
+This hides actual bugs and makes users and devs think all worked while
+it did not.
+Change to use TORCH_INTERNAL_ASSERT(false, "msg")
+
+Subject: [PATCH 2/2] Add missing skip decorator for
+test_preserve_bundled_inputs_methods
+
+This test uses optimize_for_mobile which requires NNPACK to work
+
+diff --git a/aten/src/ATen/native/BinaryOps.cpp b/aten/src/ATen/native/BinaryOps.cpp
+index c4edadb03e..e889cd03a8 100644
+--- a/aten/src/ATen/native/BinaryOps.cpp
++++ b/aten/src/ATen/native/BinaryOps.cpp
+@@ -106,6 +106,7 @@ Tensor& add_relu_impl(
+     max_val = std::numeric_limits<double>::max();
+   } else {
+     TORCH_INTERNAL_ASSERT(
++        false,
+         "Unsupported datatype for add_relu:", self.dtype().name());
+   }
+ 
+diff --git a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+index 050fdce2ca..7e72263917 100644
+--- a/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
++++ b/aten/src/ATen/native/quantized/cpu/qembeddingbag.cpp
+@@ -780,6 +780,7 @@ class QEmbeddingBag final {
+           include_last_offset);
+     } else {
+       TORCH_INTERNAL_ASSERT(
++          false,
+           "Currently only support 8-bit embedding_bag quantization");
+     }
+   }
+@@ -808,6 +809,7 @@ class QEmbedding final {
+ 
+     } else {
+       TORCH_INTERNAL_ASSERT(
++          false,
+           "Currently only support 8-bit embedding quantization");
+     }
+     return output;
+diff --git a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+index 6de646acfe..66341c959d 100644
+--- a/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
++++ b/aten/src/ATen/native/quantized/cpu/qnnpack_utils.h
+@@ -131,6 +131,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
+ 
+           if (conv_p.per_channel && conv_p.ukernel_type == pytorch_qnnp_ukernel_type_xzp_gemm) {
+             TORCH_INTERNAL_ASSERT(
++              false,
+               "Per channel quantized weights are not supported for XZP kernels");
+           }
+ 
+@@ -140,6 +141,7 @@ struct PackedConvWeightsQnnp : public ConvPackedParamsBase<kSpatialDim> {
+               static_cast<pytorch_qnnp_operator_t>(calloc(1, sizeof(struct pytorch_qnnp_operator)));
+           if (convolution == nullptr) {
+             TORCH_INTERNAL_ASSERT(
++                false,
+                 "failed to allocate %zu bytes for pytorch_qnnp_operator structure",
+                 sizeof(struct pytorch_qnnp_operator));
+           }
+@@ -406,7 +408,7 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
+               128);
+     }
+   } else {
+-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
++    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
+   }
+   at:: Tensor weight_scales =
+     at::empty(
+@@ -423,7 +425,7 @@ std::pair<std::vector<uint8_t>, at::Tensor> make_zero_points_and_scales_tensor(
+         weight_contig.q_per_channel_scales()[i].item<float>();
+     }
+   } else {
+-    TORCH_INTERNAL_ASSERT("Unsupported quantization scheme.");
++    TORCH_INTERNAL_ASSERT(false, "Unsupported quantization scheme.");
+   }
+   for (int i = num_output_channels; i <  num_output_channels_padded; ++i) {
+     weight_scales_data[i] = 1.f;
+diff --git a/test/test_mobile_optimizer.py b/test/test_mobile_optimizer.py
+index 11ef019a26..7b5ac1a239 100644
+--- a/test/test_mobile_optimizer.py
++++ b/test/test_mobile_optimizer.py
+@@ -269,6 +269,9 @@ class TestOptimizer(TestCase):
+         bi_module_lint_list = generate_mobile_module_lints(bi_module)
+         self.assertEqual(len(bi_module_lint_list), 0)
+ 
++    @unittest.skipUnless(torch.backends.xnnpack.enabled,
++                         " XNNPACK must be enabled for these tests."
++                         " Please build with USE_XNNPACK=1.")
+     def test_preserve_bundled_inputs_methods(self):
+         class MyBundledInputModule(torch.nn.Module):
+             def __init__(self):
+diff --git a/torch/csrc/jit/api/module.cpp b/torch/csrc/jit/api/module.cpp
+index 38592b80b9..8f9508321b 100644
+--- a/torch/csrc/jit/api/module.cpp
++++ b/torch/csrc/jit/api/module.cpp
+@@ -305,7 +305,7 @@ void Module::train(bool on) {
+     if (auto slot = m._ivalue()->type()->findAttributeSlot("training")) {
+       m._ivalue()->setSlot(*slot, on);
+     } else {
+-      TORCH_INTERNAL_ASSERT("'training' attribute not found");
++      TORCH_INTERNAL_ASSERT(false, "'training' attribute not found");
+     }
+   }
+ }
+diff --git a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+index 53a13b6cf1..93c2b5a7da 100644
+--- a/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
++++ b/torch/csrc/jit/passes/quantization/insert_quant_dequant.cpp
+@@ -304,6 +304,7 @@ Node* insertEmbeddingBagOps(Node* observer, const std::string& op_name) {
+     quant_fn = "quantized::embedding_bag_byte_rowwise_offsets";
+   } else {
+     TORCH_INTERNAL_ASSERT(
++        false,
+         "Graph Mode Quantization currently supports 4-bit and 8-bit embedding bag quantization.");
+   }
+ 
+diff --git a/torch/csrc/jit/passes/xnnpack_rewrite.cpp b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+index 3be480068c..2289f028ae 100644
+--- a/torch/csrc/jit/passes/xnnpack_rewrite.cpp
++++ b/torch/csrc/jit/passes/xnnpack_rewrite.cpp
+@@ -405,21 +405,25 @@ script::Module optimizeForMobile(
+ 
+ void insertPrePackedOps(std::shared_ptr<Graph>& graph) {
+   TORCH_INTERNAL_ASSERT(
++      false,
+       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+ }
+ 
+ void insertPrePackedOps(script::Module& module) {
+   TORCH_INTERNAL_ASSERT(
++      false,
+       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+ }
+ 
+ void fusePrePackedLinearConvWithClamp(script::Module& module) {
+   TORCH_INTERNAL_ASSERT(
++      false,
+       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+ }
+ 
+ void FoldPrePackingOps(script::Module& m) {
+   TORCH_INTERNAL_ASSERT(
++      false,
+       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+ }
+ 
+@@ -428,6 +432,7 @@ script::Module optimizeForMobile(
+     const std::set<MobileOptimizerType>& blocklist,
+     const std::vector<std::string>& preserved_methods) {
+   TORCH_INTERNAL_ASSERT(
++      false,
+       "Mobile optimization only available with XNNPACK at the moment. "
+       "XNNPACK is not enabled. Please build with USE_XNNPACK=1");
+   return module;
+diff --git a/torch/csrc/jit/runtime/register_ops_utils.cpp b/torch/csrc/jit/runtime/register_ops_utils.cpp
+index 537716e1ad..3bcff0af55 100644
+--- a/torch/csrc/jit/runtime/register_ops_utils.cpp
++++ b/torch/csrc/jit/runtime/register_ops_utils.cpp
+@@ -182,7 +182,7 @@ IValue tensorToListRecursive(
+     } else if (inner_result.isBool()) {
+       result.emplace_back(inner_result.toBool());
+     } else {
+-      TORCH_INTERNAL_ASSERT("Unknown return type for tensorToListRecursive");
++      TORCH_INTERNAL_ASSERT(false, "Unknown return type for tensorToListRecursive");
+     }
+ 
+     data += strides[cur_dim] * element_size;
+diff --git a/torch/csrc/distributed/c10d/ProcessGroup.cpp b/torch/csrc/distributed/c10d/ProcessGroup.cpp
+index 7909bfa7c9..9e2a51f291 100644
+--- a/torch/csrc/distributed/c10d/ProcessGroup.cpp
++++ b/torch/csrc/distributed/c10d/ProcessGroup.cpp
+@@ -43,7 +43,7 @@ std::string opTypeToString(OpType opType) {
+     case OpType::UNKNOWN:
+       return "UNKNOWN";
+     default:
+-      TORCH_INTERNAL_ASSERT("Unknown op type!");
++      TORCH_INTERNAL_ASSERT(false, "Unknown op type!");
+   }
+   return "UNKNOWN";
+ }

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-test-cond-cpu.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-test-cond-cpu.patch
@@ -1,0 +1,32 @@
+# Author: Caspar van Leeuwen, SURF
+#
+# Tests test_cond_cpu_complex128, test_cond_cpu_complex64,
+# test_cond_cpu_float32, test_cond_cpu_float64, failed with 
+# "numpy.linalg.LinAlgError: SVD did not converge"
+# when numpy was build with OpenBLAS 0.3.15 or newer.
+# Now, these tests simply pass if this error is raised.
+#
+# See https://github.com/pytorch/pytorch/issues/67675
+# Patch based on https://github.com/pytorch/pytorch/pull/67679
+---
+ test/test_linalg.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/test/test_linalg.py b/test/test_linalg.py
+index d7494dfebe10..9eb3d0bf7d99 100644
+--- a/test/test_linalg.py
++++ b/test/test_linalg.py
+@@ -1638,7 +1638,12 @@ def run_test_case(input, p):
+         a = torch.eye(3, dtype=dtype, device=device)
+         a[-1, -1] = 0  # make 'a' singular
+         for p in norm_types:
+-            run_test_case(a, p)
++            try:
++                run_test_case(a, p)
++            except np.linalg.LinAlgError:
++                # Numpy may fail to converge for some BLAS backends
++                # See the discussion in https://github.com/pytorch/pytorch/issues/67675
++                pass
+ 
+         # test for 0x0 matrices. NumPy doesn't work for such input, we return 0
+         input_sizes = [(0, 0), (2, 5, 0, 0)]

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-test-dataloader-fixed-affinity.patch
@@ -1,0 +1,40 @@
+# Author: Alexander Grund
+# Avoid test failures in CGROUP environments
+# See https://github.com/pytorch/pytorch/issues/44368 and https://github.com/pytorch/pytorch/pull/44369
+diff -Nru pytorch.orig/test/test_dataloader.py pytorch/test/test_dataloader.py
+--- pytorch.orig/test/test_dataloader.py	2021-10-28 19:19:23.284526686 +0200
++++ pytorch/test/test_dataloader.py	2021-10-28 19:21:31.860488973 +0200
+@@ -2374,22 +2374,27 @@
+         after = os.sched_getaffinity(0)
+         return iter(after)
+ 
+-
+-def worker_set_affinity(_):
+-    os.sched_setaffinity(0, [multiprocessing.cpu_count() - 1])
+-
+-
+ @unittest.skipIf(
+     not hasattr(os, 'sched_setaffinity'),
+     "os.sched_setaffinity is not available")
+ class TestSetAffinity(TestCase):
+     def test_set_affinity_in_worker_init(self):
++        # Query the current affinity mask to avoid setting a disallowed one
++        old_affinity = os.sched_getaffinity(0)
++        if not old_affinity:
++            self.skipTest("No affinity information")
++        # Choose any
++        expected_affinity = list(old_affinity)[-1]
++
++        def worker_set_affinity(_):
++            os.sched_setaffinity(0, [expected_affinity])
++
+         dataset = SetAffinityDataset()
+ 
+         dataloader = torch.utils.data.DataLoader(
+             dataset, num_workers=2, worker_init_fn=worker_set_affinity)
+         for sample in dataloader:
+-            self.assertEqual(sample, [multiprocessing.cpu_count() - 1])
++            self.assertEqual(sample, [expected_affinity])
+ 
+ class ConvDataset(Dataset):
+     def __init__(self):

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-vnni-detection.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_fix-vnni-detection.patch
@@ -1,0 +1,22 @@
+# Author: Caspar van Leeuwen, SURF
+# 
+# A bug in the test_lstm test was triggered on machines with AVX512_vnni support
+# See https://github.com/pytorch/pytorch/issues/59098
+# It was supposed to skip this test based on IS_AVX512_VNNI_SUPPORTED
+# But the test function only searched for 'avx512vnni', while my /proc/cpuinfo 
+# contained 'avx512_vnni'
+# This patch should fix the avx512_vnni detection and skip any incompatible tests
+# VNNI detection issue: https://github.com/pytorch/pytorch/issues/67685
+# And PR: https://github.com/pytorch/pytorch/pull/67686
+diff -Nru pytorch.orig/torch/testing/_internal/common_utils.py pytorch/torch/testing/_internal/common_utils.py
+--- pytorch.orig/torch/testing/_internal/common_utils.py	2021-11-02 15:50:14.328727067 +0100
++++ pytorch/torch/testing/_internal/common_utils.py	2021-11-02 15:59:44.621177782 +0100
+@@ -620,7 +620,7 @@
+         return False
+     with open("/proc/cpuinfo", encoding="ascii") as f:
+         lines = f.read()
+-    return "avx512vnni" in lines
++    return any(s in lines for s in ("avx512_vnni", "avx512vnni"))
+ 
+ IS_AVX512_VNNI_SUPPORTED = is_avx512_vnni_supported()
+ 

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_increase_zero_optimizer_test_tolerance.patch
@@ -1,0 +1,26 @@
+# Author: Caspar van Leeuwen, SURF
+# Fixes failing tests in test_zero_redundancy_optimizer for A100 due to the use of TensorFloat32
+# We increase tolerances in the assert's, so that the small differences that arise due to the 
+# use of TensorFloat32 fall within the limits of torch.allclose(...)
+# See https://github.com/pytorch/pytorch/issues/67764
+diff -Nru pytorch.orig/test/distributed/optim/test_zero_redundancy_optimizer.py pytorch/test/distributed/optim/test_zero_redundancy_optimizer.py
+--- pytorch.orig/test/distributed/optim/test_zero_redundancy_optimizer.py	2021-11-02 15:50:15.430729833 +0100
++++ pytorch/test/distributed/optim/test_zero_redundancy_optimizer.py	2021-11-03 14:38:23.244771749 +0100
+@@ -881,13 +881,15 @@
+                 local_loss = cast(torch.Tensor, local_optim.step(closure=closure_local))
+                 ddp_loss = cast(torch.Tensor, zero_optim.step(closure=closure_ddp)).to(cpu_device)
+ 
++                # Increased tolerances are needed to pass test when using TensorFloat32
++                # see https://github.com/pytorch/pytorch/issues/67764
+                 assert torch.allclose(
+-                    local_loss, ddp_loss
++                    local_loss, ddp_loss, rtol=1e-03
+                 ), "Losses differ between local optim and ZeroRedundancyOptimizer"
+ 
+                 for local_p, ddp_p in zip(local_model.parameters(), ddp_model.parameters()):
+                     ddp_p = ddp_p.to(cpu_device)
+-                    assert torch.allclose(local_p, ddp_p), "Models differ after a step"
++                    assert torch.allclose(local_p, ddp_p, rtol=1e-04, atol=1e-04), "Models differ after a step"
+ 
+     @common_distributed.skip_if_lt_x_gpu(4)
+     def test_zero_model_parallel_with_bucket_view(self):

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_cmake_rpath.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_cmake_rpath.patch
@@ -1,0 +1,195 @@
+# Author: Caspar van Leeuwen
+# PyTorch's CMAKE configuration by default sets RUNPATH on libraries if they link other libraries
+# that are outside the build tree, which is done because of the CMAKE config on 
+# https://github.com/pytorch/pytorch/blob/v1.10.0/cmake/Dependencies.cmake#L10.
+# This provides problems, since the cuda stubs library path then also gets added to the RUNPATH.
+# As a result, at runtime, the stub version of things like libcuda.so.1 gets picked up, instead of the real drivers
+# See https://github.com/easybuilders/easybuild-easyconfigs/issues/14359
+# This line https://github.com/pytorch/pytorch/blob/v1.10.0/cmake/Dependencies.cmake#L16
+# Makes sure that any path that is linked, is also added to the RUNPATH.
+# This has been reported upstream in https://github.com/pytorch/pytorch/issues/35418
+# and a fix was attempted in https://github.com/pytorch/pytorch/pull/37737 but it was reverted
+#
+# This EasyBuild patch changes behavior for the libraries that were failing, i.e. the ones in this list:
+# https://github.com/easybuilders/easybuild-easyconfigs/issues/14359#issuecomment-970479904
+# This is done by setting INSTALL_RPATH_USE_LINK_PATH to false, and instead, specifying the RPATH
+# explicitely by defining INSTALL_RPATH, but only adding directories that do not match to the "stubs" regex
+# It has been upstreamed in this PR https://github.com/pytorch/pytorch/pull/68912 (not accepted yet at the time of writing)
+diff -Nru pytorch.orig/caffe2/CMakeLists.txt pytorch/caffe2/CMakeLists.txt
+--- pytorch.orig/caffe2/CMakeLists.txt	2021-11-17 11:46:01.797337624 +0100
++++ pytorch/caffe2/CMakeLists.txt	2021-11-18 19:05:35.637707235 +0100
+@@ -630,8 +630,33 @@
+     else()
+       set(DELAY_LOAD_FLAGS "")
+     endif()
+-    target_link_libraries(caffe2_nvrtc ${CUDA_NVRTC} ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB} ${DELAY_LOAD_FLAGS})
++    # message("CUDA_NVRTC: ${CUDA_NVRTC}")
++    # message("CUDA_NVRTC_LIB: ${CUDA_NVRTC_LIB}")
++    # message("CUDA_CUDA_LIB: ${CUDA_CUDA_LIB}")
++    # message("DELAY_LOAD_FLAGS: ${DELAY_LOAD_FLAGS}")
++    # if(CUDA_CUDA_LIB MATCHES "stubs")
++    #   message("stubs libraries found in the CUDA_CUDA_LIB: ${CUDA_CUDA_LIB}")
++    # else()
++    #   message("Stubs libs not found in CUDA_CUDA_LIB: ${CUDA_CUDA_LIB}")
++    # endif()
++    # Make sure the CUDA stubs folder doesn't end up in the RPATH of CAFFE2_NVRTC:
++    set(CAFFE2_NVRTC_LIBS ${CUDA_NVRTC} ${CUDA_CUDA_LIB} ${CUDA_NVRTC_LIB})
++    foreach(LIB IN LISTS CAFFE2_NVRTC_LIBS)
++      message("LIB: ${LIB}")
++      if(LIB MATCHES "stubs")
++        message("Filtering ${LIB} from being set in caffe2_nvrtc's RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++      else()
++        cmake_path(GET LIB PARENT_PATH LIB_PATH)
++        message("LIBPATH: ${LIB_PATH}")
++	list(APPEND CAFFE2_NVRTC_RPATH ${LIB_PATH})
++      endif()
++    endforeach()
++    message("CAFFE2_NVRTC_RPATH: ${CAFFE2_NVRTC_RPATH}")
++    set_target_properties(caffe2_nvrtc PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++    set_target_properties(caffe2_nvrtc PROPERTIES INSTALL_RPATH "${CAFFE2_NVRTC_RPATH}")
++    target_link_libraries(caffe2_nvrtc ${CAFFE2_NVRTC_LIBS} ${DELAY_LOAD_FLAGS})
+     target_include_directories(caffe2_nvrtc PRIVATE ${CUDA_INCLUDE_DIRS})
++#    message(FATAL_ERROR "STOP HERE, we're debugging")
+     install(TARGETS caffe2_nvrtc DESTINATION "${TORCH_INSTALL_LIB_DIR}")
+     if(USE_NCCL AND BUILD_SPLIT_CUDA)
+       list(APPEND Caffe2_GPU_SRCS_CPP
+diff -Nru pytorch.orig/test/cpp/api/CMakeLists.txt pytorch/test/cpp/api/CMakeLists.txt
+--- pytorch.orig/test/cpp/api/CMakeLists.txt	2021-11-17 11:46:02.991350652 +0100
++++ pytorch/test/cpp/api/CMakeLists.txt	2021-11-18 19:06:41.207423777 +0100
+@@ -61,6 +61,22 @@
+     ${CUDA_CUDA_LIB}
+     ${TORCH_CUDA_LIBRARIES})
+ 
++  # Make sure the CUDA stubs folder doesn't end up in the RPATH of test_api:
++  set(TEST_API_LIBS ${CUDA_LIBRARIES} ${CUDA_NVRTC_LIB} ${CUDA_CUDA_LIB} ${TORCH_CUDA_LIBRARIES})
++  foreach(LIB IN LISTS TEST_API_LIBS)
++    message("LIB: ${LIB}")
++    if(LIB MATCHES "stubs")
++      message("Filtering ${LIB} from being set in caffe2_nvrtc's RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++    else()
++      cmake_path(GET LIB PARENT_PATH LIB_PATH)
++      message("LIBPATH: ${LIB_PATH}")
++      list(APPEND TEST_API_RPATH ${LIB_PATH})
++    endif()
++  endforeach()
++  message("TEST_API_RPATH: ${TEST_API_RPATH}")
++  set_target_properties(test_api PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++  set_target_properties(test_api PROPERTIES INSTALL_RPATH "${TEST_API_RPATH}")
++
+   target_compile_definitions(test_api PRIVATE "USE_CUDA")
+ endif()
+ 
+diff -Nru pytorch.orig/test/cpp/dist_autograd/CMakeLists.txt pytorch/test/cpp/dist_autograd/CMakeLists.txt
+--- pytorch.orig/test/cpp/dist_autograd/CMakeLists.txt	2021-11-17 11:46:02.993350674 +0100
++++ pytorch/test/cpp/dist_autograd/CMakeLists.txt	2021-11-18 19:06:18.389174421 +0100
+@@ -16,6 +16,22 @@
+       ${CUDA_CUDA_LIB}
+       ${TORCH_CUDA_LIBRARIES})
+ 
++    # Make sure the CUDA stubs folder doesn't end up in the RPATH of test_dist_autograd:
++    set(DIST_AUTOGRAD_LIBS ${CUDA_LIBRARIES} ${CUDA_NVRTC_LIB} ${CUDA_CUDA_LIB} ${TORCH_CUDA_LIBRARIES})
++    foreach(LIB IN LISTS DIST_AUTOGRAD_LIBS)
++      message("LIB: ${LIB}")
++      if(LIB MATCHES "stubs")
++        message("Filtering ${LIB} from being set in caffe2_nvrtc's RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++      else()
++        cmake_path(GET LIB PARENT_PATH LIB_PATH)
++        message("LIBPATH: ${LIB_PATH}")
++        list(APPEND DIST_AUTOGRAD_RPATH ${LIB_PATH})
++      endif()
++    endforeach()
++    message("DIST_AUTOGRAD_RPATH: ${DIST_AUTOGRAD_RPATH}")
++    set_target_properties(test_dist_autograd PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++    set_target_properties(test_dist_autograd PROPERTIES INSTALL_RPATH "${DIST_AUTOGRAD_RPATH}")
++
+     target_compile_definitions(test_dist_autograd PRIVATE "USE_CUDA")
+   endif()
+ 
+diff -Nru pytorch.orig/test/cpp/jit/CMakeLists.txt pytorch/test/cpp/jit/CMakeLists.txt
+--- pytorch.orig/test/cpp/jit/CMakeLists.txt	2021-11-17 11:46:02.989350630 +0100
++++ pytorch/test/cpp/jit/CMakeLists.txt	2021-11-18 19:05:41.396770168 +0100
+@@ -94,6 +94,7 @@
+   list(APPEND JIT_TEST_DEPENDENCIES onnx_library)
+ endif(MSVC)
+ 
++
+ target_link_libraries(test_jit PRIVATE ${JIT_TEST_DEPENDENCIES})
+ target_include_directories(test_jit PRIVATE ${ATen_CPU_INCLUDE})
+ 
+@@ -109,6 +110,22 @@
+     ${CUDA_CUDA_LIB}
+     ${TORCH_CUDA_LIBRARIES})
+ 
++  # Make sure the CUDA stubs folder doesn't end up in the RPATH of test_jit:
++  set(TEST_JIT_LIBS ${CUDA_LIBRARIES} ${CUDA_NVRTC_LIB} ${CUDA_CUDA_LIB} ${TORCH_CUDA_LIBRARIES})
++  foreach(LIB IN LISTS TEST_JIT_LIBS)
++    message("LIB: ${LIB}")
++    if(LIB MATCHES "stubs")
++      message("Filtering ${LIB} from being set in test_jit's RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++    else()
++      cmake_path(GET LIB PARENT_PATH LIB_PATH)
++      message("LIBPATH: ${LIB_PATH}")
++      list(APPEND TEST_JIT_RPATH ${LIB_PATH})
++    endif()
++  endforeach()
++  message("TEST_JIT_RPATH: ${TEST_JIT_RPATH}")
++  set_target_properties(test_jit PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++  set_target_properties(test_jit PROPERTIES INSTALL_RPATH "${TEST_JIT_RPATH}")
++
+   target_compile_definitions(test_jit PRIVATE USE_CUDA)
+ elseif(USE_ROCM)
+   target_link_libraries(test_jit PRIVATE
+diff -Nru pytorch.orig/test/cpp/rpc/CMakeLists.txt pytorch/test/cpp/rpc/CMakeLists.txt
+--- pytorch.orig/test/cpp/rpc/CMakeLists.txt	2021-11-17 11:46:02.991350652 +0100
++++ pytorch/test/cpp/rpc/CMakeLists.txt	2021-11-18 19:06:30.502306793 +0100
+@@ -39,6 +39,22 @@
+     ${CUDA_CUDA_LIB}
+     ${TORCH_CUDA_LIBRARIES})
+ 
++  # Make sure the CUDA stubs folder doesn't end up in the RPATH of test_cpp_rpc:
++  set(CPP_RPC_LIBS ${CUDA_LIBRARIES} ${CUDA_NVRTC_LIB} ${CUDA_CUDA_LIB} ${TORCH_CUDA_LIBRARIES})
++  foreach(LIB IN LISTS CPP_RPC_LIBS)
++    message("LIB: ${LIB}")
++    if(LIB MATCHES "stubs")
++      message("Filtering ${LIB} from being set in caffe2_nvrtc's RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++    else()
++      cmake_path(GET LIB PARENT_PATH LIB_PATH)
++      message("LIBPATH: ${LIB_PATH}")
++      list(APPEND CPP_RPC_RPATH ${LIB_PATH})
++    endif()
++  endforeach()
++  message("CPP_RPC_RPATH: ${CPP_RPC_RPATH}")
++  set_target_properties(test_cpp_rpc PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++  set_target_properties(test_cpp_rpc PROPERTIES INSTALL_RPATH "${CPP_RPC_RPATH}")
++
+   target_compile_definitions(test_cpp_rpc PRIVATE "USE_CUDA")
+ endif()
+ 
+diff -Nru pytorch.orig/test/cpp/tensorexpr/CMakeLists.txt pytorch/test/cpp/tensorexpr/CMakeLists.txt
+--- pytorch.orig/test/cpp/tensorexpr/CMakeLists.txt	2021-11-17 11:46:02.993350674 +0100
++++ pytorch/test/cpp/tensorexpr/CMakeLists.txt	2021-11-18 19:06:00.988984273 +0100
+@@ -62,6 +62,24 @@
+     ${CUDA_CUDA_LIB}
+     ${TORCH_CUDA_LIBRARIES})
+   target_compile_definitions(tutorial_tensorexpr PRIVATE USE_CUDA)
++
++  # Make sure the CUDA stubs folder doesn't end up in the RPATH of tutorial_tensorexpr:
++  set(CUDA_LINK_LIBS ${CUDA_LIBRARIES} ${CUDA_NVRTC_LIB} ${CUDA_CUDA_LIB} ${TORCH_CUDA_LIBRARIES})
++  foreach(LIB IN LISTS CUDA_LINK_LIBS)
++    message("LIB: ${LIB}")
++    if(LIB MATCHES "stubs")
++      message("Filtering ${LIB} from being set in test_tensorexpr and tutorial_tensorexpr RPATH, because it appears to point to the CUDA stubs directory, which should not be RPATHed.")
++    else()
++      cmake_path(GET LIB PARENT_PATH LIB_PATH)
++      message("LIBPATH: ${LIB_PATH}")
++      list(APPEND TENSOREXPR_RPATH ${LIB_PATH})
++    endif()
++  endforeach()
++  message("TENSOREXPR_RPATH: ${TENSOREXPR_RPATH}")
++  set_target_properties(test_tensorexpr PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++  set_target_properties(test_tensorexpr PROPERTIES INSTALL_RPATH "${TENSOREXPR_RPATH}")
++  set_target_properties(tutorial_tensorexpr PROPERTIES INSTALL_RPATH_USE_LINK_PATH FALSE)
++  set_target_properties(tutorial_tensorexpr PROPERTIES INSTALL_RPATH "${TENSOREXPR_RPATH}")
+ elseif(USE_ROCM)
+   target_link_libraries(test_tensorexpr PRIVATE
+     ${ROCM_HIPRTC_LIB}

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_failing_ops_tests.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_failing_ops_tests.patch
@@ -1,0 +1,33 @@
+# Author: Caspar van Leeuwen, SURF
+# Test 'test_fn_grad_linalg_det_singular_cpu_complex128' was failing
+# It was noticed by the PyTorch devs that this is flaky and recommended to skip it for now
+# See https://github.com/pytorch/pytorch/issues/67767
+# Test 'test_variant_consistency_jit_contiguous_cpu_float32' was also failing
+# However, the test passes when run individually
+# See https://github.com/pytorch/pytorch/issues/67838
+diff -Nru pytorch.orig/torch/testing/_internal/common_methods_invocations.py pytorch/torch/testing/_internal/common_methods_invocations.py
+--- pytorch.orig/torch/testing/_internal/common_methods_invocations.py	2021-11-02 15:50:14.328727067 +0100
++++ pytorch/torch/testing/_internal/common_methods_invocations.py	2021-11-04 12:04:29.794149360 +0100
+@@ -6448,7 +6448,10 @@
+            supports_forward_ad=True,
+            autodiff_fusible_nodes=['aten::contiguous'],
+            assert_jit_shape_analysis=True,
+-           supports_out=False),
++           supports_out=False,
++           skips=(
++               DecorateInfo(unittest.skip("Skipped!"), 'TestJit', 'test_variant_consistency_jit', device_type='cpu'),
++           )),
+     OpInfo('symeig',
+            dtypes=floating_and_complex_types(),
+            check_batched_gradgrad=False,
+@@ -7060,6 +7063,10 @@
+                # Probable fix (open PR): https://github.com/pytorch/pytorch/pull/62570
+                DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', 'test_fn_grad', device_type='cuda',
+                             dtypes=(torch.complex128,)),
++               # It also breaks on CPU. We'll revisit this once `linalg.lu_solve` is a thing
++               # See https://github.com/pytorch/pytorch/pull/64387 and https://github.com/pytorch/pytorch/issues/67767
++               DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', 'test_fn_grad',
++                            dtypes=(torch.complex128,)),
+                DecorateInfo(unittest.skip("Skipped!"), 'TestCommon', 'test_dtypes'),
+                DecorateInfo(unittest.skip("Skipped!"), 'TestGradients', 'test_fn_gradgrad'),
+                # This test fails because singular inputs cannot be reliably

--- a/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_nan_tests_openblas.patch
+++ b/easybuild/easyconfigs/p/PyTorch/PyTorch-1.10.0_skip_nan_tests_openblas.patch
@@ -1,0 +1,54 @@
+# Author: Caspar van Leeuwen, SURF
+# Skip tests that fail due to how OpenBLAS 0.3.15 and later handle NaN inputs
+# This affects the following tests:
+# ERROR: test_norm_extreme_values_cpu (__main__.TestLinalgCPU)
+# FAIL: test_svd_errors_and_warnings_cpu_complex64 (__main__.TestLinalgCPU)
+# FAIL: test_svd_errors_and_warnings_cpu_float32 (__main__.TestLinalgCPU)
+# FAIL: test_svd_errors_and_warnings_cpu_float64 (__main__.TestLinalgCPU)
+# See https://github.com/pytorch/pytorch/issues/67693
+diff -Nru pytorch.orig/test/test_linalg.py pytorch/test/test_linalg.py
+--- pytorch.orig/test/test_linalg.py	2021-11-02 15:50:15.433729841 +0100
++++ pytorch/test/test_linalg.py	2021-11-03 10:46:52.910339202 +0100
+@@ -1873,6 +1873,11 @@
+                     # These cases are broken because of another issue with svd
+                     # https://github.com/pytorch/pytorch/issues/52633
+                     return True
++            if self.device_type == 'cpu':
++                if torch.any(torch.isnan(x)):
++                    # This case is broken when cpu backend is OpenBLAS >= 0.3.15
++                    # See https://github.com/pytorch/pytorch/issues/67693
++                    return True
+             return False
+ 
+         for matrix in matrices:
+@@ -2896,15 +2901,17 @@
+                     # error from out_v
+                     svd(a, out=(out_u, out_s, out_v))
+ 
++            # Skip test for NaNs, it fails with OpenBLAS since it produces a different error than expected
++            # See https://github.com/pytorch/pytorch/issues/67693
+             # if input contains NaN then an error is triggered for svd
+-            a = torch.full((3, 3), float('nan'), dtype=dtype, device=device)
+-            a[0] = float('nan')
+-            with self.assertRaisesRegex(RuntimeError, "The algorithm failed to converge"):
+-                svd(a)
+-            a = torch.randn(3, 33, 33, dtype=dtype, device=device)
+-            a[1, 0, 0] = float('nan')
+-            with self.assertRaisesRegex(RuntimeError, r"\(Batch element 1\): The algorithm failed to converge"):
+-                svd(a)
++            # a = torch.full((3, 3), float('nan'), dtype=dtype, device=device)
++            # a[0] = float('nan')
++            # with self.assertRaisesRegex(RuntimeError, "The algorithm failed to converge"):
++            #     svd(a)
++            # a = torch.randn(3, 33, 33, dtype=dtype, device=device)
++            # a[1, 0, 0] = float('nan')
++            # with self.assertRaisesRegex(RuntimeError, r"\(Batch element 1\): The algorithm failed to converge"):
++            #     svd(a)
+ 
+     @skipCUDAIfNoMagmaAndNoCusolver
+     @skipCPUIfNoLapack
+Binary files pytorch.orig/torch/__pycache__/autocast_mode.cpython-39.pyc and pytorch/torch/__pycache__/autocast_mode.cpython-39.pyc differ
+Binary files pytorch.orig/torch/__pycache__/__init__.cpython-39.pyc and pytorch/torch/__pycache__/__init__.cpython-39.pyc differ
+Binary files pytorch.orig/torch/__pycache__/torch_version.cpython-39.pyc and pytorch/torch/__pycache__/torch_version.cpython-39.pyc differ
+Binary files pytorch.orig/torch/__pycache__/_utils.cpython-39.pyc and pytorch/torch/__pycache__/_utils.cpython-39.pyc differ
+Binary files pytorch.orig/torch/__pycache__/_utils_internal.cpython-39.pyc and pytorch/torch/__pycache__/_utils_internal.cpython-39.pyc differ


### PR DESCRIPTION
For INC1188943 - IceLake prep

* [x] Assigned to reviewers (usually everyone in apps team)

`PyTorch-1.10.0-foss-2021a.eb`:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

`PyTorch-1.10.0-foss-2021a-CUDA-11.3.1.eb` - build with `--ignore-test-failure`:
* [x] EL8-icelake
* [x] EL8-haswell

I've had random, different `test_jit*` tests fail with `SIGSEGV` on the different builds I've done.