### PR TITLE
Minimac4 replacing deprecated 2018b version

### DIFF
--- a/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/l/libStatGen/libStatGen-1.0.15-GCCcore-10.3.0.eb
@@ -1,0 +1,34 @@
+# This easyconfig was created by Simon Branford of the BEAR Software team at the University of Birmingham.
+easyblock = 'MakeCp'
+
+name = 'libStatGen'
+version = '1.0.15'
+_hash = 'ff4f2fc'
+
+homepage = "https://genome.sph.umich.edu/wiki/C++_Library:_libStatGen"
+description = """Useful set of classes for creating statistical genetic programs."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+github_account = 'statgen'
+source_urls = [GITHUB_SOURCE]
+sources = [{'download_filename': '%s.tar.gz' % _hash, 'filename': SOURCELOWER_TAR_GZ}]
+checksums = ['68acb15b6c85f07b0dbf3f8b7a2a99a88fc97d3e29e80bebab82bd2a8e09121e']
+
+builddependencies = [('binutils', '2.36.1')]
+
+dependencies = [('zlib', '1.2.11')]
+
+runtest = 'test'
+
+files_to_copy = [
+    (['libStatGen.a'], 'lib'),
+    ('include'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libStatGen.a', 'include/VcfFile.h', 'include/SamFile.h', 'include/BamIndex.h', 'include/Cigar.h'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/Minimac4/Minimac4-1.0.2-foss-2021a.eb
+++ b/easybuild/easyconfigs/m/Minimac4/Minimac4-1.0.2-foss-2021a.eb
@@ -1,0 +1,32 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'CMakeMake'
+
+name = 'Minimac4'
+version = '1.0.2'
+
+homepage = 'https://genome.sph.umich.edu/wiki/Minimac4'
+description = """Minimac4 is a latest version in the series of genotype imputation software - preceded by
+ Minimac3 (2015), Minimac2 (2014), minimac (2012) and MaCH (2010). Minimac4 is a lower memory and more
+ computationally efficient implementation of the original algorithms with comparable imputation quality."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+source_urls = ['https://github.com/statgen/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+checksums = ['d010ee9b4c50de8f0617e21f69fcbbb23115c2d3b3db2e9681b694c1e875569f']
+
+builddependencies = [('CMake', '3.20.1')]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libStatGen', '1.0.15'),
+]
+
+configopts = '-DCMAKE_BUILD_TYPE=Release'
+
+sanity_check_paths = {
+    'files': ['bin/minimac4'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1220150 - `Minimac4-1.0.2-foss-2021a.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell

2018b version wasn't loaded on U20 (according to the modules logging database) so let's not install it on there this time.
