### PR TITLE
PEAR updated to newer toolchain

### DIFF
--- a/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/p/PEAR/PEAR-0.9.11-GCCcore-10.2.0.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'PEAR'
+version = '0.9.11'
+
+homepage = 'https://cme.h-its.org/exelixis/web/software/%(namelower)s/'
+description = """PEAR is an ultrafast, memory-efficient and highly accurate pair-end read merger. 
+ It is fully parallelized and can run with as low as just a few kilobytes of memory."""
+
+toolchain = {'name': 'GCCcore', 'version': '10.2.0'}
+
+# Needs manual download via web-form,
+# https://www.h-its.org/en/research/sco/software/#NextGenerationSequencingSequenceAnalysis
+sources = ['%(namelower)s-src-%(version)s.tar.gz']
+checksums = ['94f4a1835cd75ec6fab83405c2545ddba6b6bb1644579222e9cc2ad57a59d654']
+
+builddependencies = [
+    ('Autotools', '20200321'),
+    ('binutils', '2.35'),
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.8'),
+]
+
+preconfigopts = 'autoreconf && '
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
For INC1230365- `PEAR-0.9.11-GCCcore-10.2.0.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-cascadelake
* [x] EL8-haswell
