### PR TITLE
Kaleido

### DIFF
--- a/easybuild/easyconfigs/k/Kaleido/Kaleido-0.2.1-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/k/Kaleido/Kaleido-0.2.1-GCCcore-10.3.0.eb
@@ -1,0 +1,25 @@
+easyblock = 'PythonPackage'
+
+name = 'Kaleido'
+version = '0.2.1'
+
+homepage = 'https://github.com/plotly/Kaleido'
+description = "Fast static image export for web-based visualization libraries with zero dependencies"
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+sources = ['kaleido-%(version)s-py2.py3-none-manylinux1_%(arch)s.whl']
+checksums = ['aa21cf1bf1c78f8fa50a9f7d45e1003c387bd3d6fe0a767cfbbf344b95bdc3a8']
+
+builddependencies = [
+    ('binutils', '2.36.1'),
+]
+
+dependencies = [('Python', '3.9.5')]
+
+download_dep_fail = True
+use_pip = True
+
+sanity_pip_check = True
+
+moduleclass = 'vis'


### PR DESCRIPTION
For INC1233735 - `Kaleido-0.2.1-GCCcore-10.3.0.eb` (from upstream)

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

