### PR TITLE
remove FFTW dep from iomkl CP2K (2021a)

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-iomkl-2021a.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-iomkl-2021a.eb
@@ -21,7 +21,8 @@ dependencies = [
     ('Libint', '2.6.0', '-lmax-6-cp2k'),
     ('libxc', '5.1.5'),
     ('libxsmm', '1.16.2'),
-    ('FFTW', '3.3.9'),
+    # use MKL FFTW instead
+    # ('FFTW', '3.3.9'),
     ('PLUMED', '2.7.2'),
 ]
 


### PR DESCRIPTION
For INC1234600

* [x] Assigned to reviewers (usually everyone in apps team)

rebuild `CP2K-9.1-iomkl-2021a.eb`:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

