### PR TITLE
remove FFTW dep from iomkl CP2K (2020b)

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-8.1-iomkl-2020b.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-8.1-iomkl-2020b.eb
@@ -18,7 +18,8 @@ dependencies = [
     ('Libint', '2.6.0', '-lmax-6-cp2k'),
     ('libxc', '4.3.4'),
     ('libxsmm', '1.16.1'),
-    ('FFTW', '3.3.8'),
+    # use MKL FFTW instead
+    # ('FFTW', '3.3.8'),
     ('PLUMED', '2.6.2'),
 ]
 


### PR DESCRIPTION
For INC1234600

* [ ] Assigned to reviewers (usually everyone in apps team)

rebuild `CP2K-8.1-iomkl-2020b.eb`:
* [ ] EL8-cascadelake
* [ ] EL8-haswell
