### PR TITLE
Fix tbl2asn in prokka

### DIFF
--- a/easybuild/easyconfigs/p/prokka/prokka-1.14.5-gompi-2019b.eb
+++ b/easybuild/easyconfigs/p/prokka/prokka-1.14.5-gompi-2019b.eb
@@ -16,13 +16,28 @@ description = """Prokka is a software tool for the rapid annotation of prokaryot
 toolchain = {'name': 'gompi', 'version': '2019b'}
 
 source_urls = ['https://github.com/tseemann/prokka/archive/']
-sources = ['v%(version)s.zip']
-checksums = ['0c13dd5621c352633565f5831c4e85ce2e1e400c2f17ba50800282ae121803ff']
+sources = [
+    {
+        'filename': 'v%(version)s.zip',
+        'extract_cmd': "unzip -qq %s",
+    },
+    {
+        'source_urls': ['ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/'],
+        'download_filename': 'linux64.tbl2asn.gz',
+        'filename': '20211031-linux64.tbl2asn.gz',
+        'extract_cmd': "gunzip -c %s > %(name)s-%(version)s/tbl2asn",
+    }
+]
+checksums = [
+    '0c13dd5621c352633565f5831c4e85ce2e1e400c2f17ba50800282ae121803ff',  # v1.14.5.zip
+    'b7edf378c971e6d7c48bf4d391d43a6d79f0e26dfa57156b4f87456af83e1fee',  # 20211031-linux64.tbl2asn.gz
+]
 
 dependencies = [
     ('BioPerl', '1.7.2'),
     ('BLAST+', '2.9.0'),
     ('Java', '11', '', True),
+    ('libidn', '1.35'),
 ]
 
 local_bin_files = ['prokka', 'prokka-cdd_to_hmm', 'prokka-genpept_to_fasta_db', 'prokka-tigrfams_to_hmm',
@@ -30,7 +45,13 @@ local_bin_files = ['prokka', 'prokka-cdd_to_hmm', 'prokka-genpept_to_fasta_db', 
                    'prokka-uniprot_to_fasta_db', 'prokka-build_kingdom_dbs', 'prokka-genbank_to_fasta_db',
                    'prokka-make_tarball']
 
-postinstallcmds = ["%(installdir)s/bin/prokka --setupdb"]
+postinstallcmds = [
+    "%(installdir)s/bin/prokka --setupdb",
+    # tbl2asn expects libidn.so.11 and the, different version, provided by the libidn seems fine for the use here
+    "mkdir %(installdir)s/lib && cd %(installdir)s/lib && ln -s $EBROOTLIBIDN/lib/libidn.so libidn.so.11",
+    # replace tbl2asn with a newer version
+    "chmod +x %(installdir)s/tbl2asn && mv %(installdir)s/tbl2asn %(installdir)s/binaries/linux/tbl2asn",
+]
 
 sanity_check_paths = {
     'files': ['bin/%s' % x for x in local_bin_files] + ['binaries/linux/aragorn', 'db/cm/Bacteria', 'doc/ToDoList.txt'],
@@ -40,6 +61,8 @@ sanity_check_paths = {
 sanity_check_commands = [
     "prokka --version",
     "prokka --listdb",
+    # check that tbl2asn works, via a prokka test
+    "cd %(builddir)s/%(name)s-%(version)s/test && prokka plasmid.fna",
 ]
 
 modloadmsg = "prokka scripts are located in $EBROOTPROKKA/bin; databases are located in $EBROOTPROKKA/db\n"

--- a/easybuild/easyconfigs/p/prokka/prokka-1.14.5-gompi-2019b.eb
+++ b/easybuild/easyconfigs/p/prokka/prokka-1.14.5-gompi-2019b.eb
@@ -47,7 +47,7 @@ local_bin_files = ['prokka', 'prokka-cdd_to_hmm', 'prokka-genpept_to_fasta_db', 
 
 postinstallcmds = [
     "%(installdir)s/bin/prokka --setupdb",
-    # tbl2asn expects libidn.so.11 and the, different version, provided by the libidn seems fine for the use here
+    # tbl2asn expects libidn.so.11 and the (different) version provided by the libidn seems fine
     "mkdir %(installdir)s/lib && cd %(installdir)s/lib && ln -s $EBROOTLIBIDN/lib/libidn.so libidn.so.11",
     # replace tbl2asn with a newer version
     "chmod +x %(installdir)s/tbl2asn && mv %(installdir)s/tbl2asn %(installdir)s/binaries/linux/tbl2asn",


### PR DESCRIPTION
For INC1243117 and INC1243407

Prokka bundles `tbl2asn` and that is only available as a binary. This PR downloads a newer `tbl2asn` and symlinks the libidn.so to be the expected version. The supplied prokka test, added in `sanity_check_commands`, completes successfully with these changes.

* [x] Assigned to reviewers (usually everyone in apps team)

rebuild `prokka-1.14.5-gompi-2019b.eb`:
* [x] EL8-cascadelake
* [x] EL8-haswell
* [x] Ubuntu20 VM

