### PR TITLE
RStudio

### DIFF
--- a/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.6.eb
+++ b/easybuild/easyconfigs/a/alsa-lib/alsa-lib-1.2.6.eb
@@ -1,0 +1,22 @@
+easyblock = 'ConfigureMake'
+
+name = 'alsa-lib'
+version = '1.2.6'
+
+homepage = 'https://www.alsa-project.org'
+description = """The Advanced Linux Sound Architecture (ALSA) provides audio and MIDI functionality
+ to the Linux operating system."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://www.alsa-project.org/files/pub/lib/']
+sources = [SOURCE_TAR_BZ2]
+checksums = ['7fe3057894ec319118abfd042ef84632a1dcd911806ec9fff6daaa68d15a8c52']
+
+sanity_check_paths = {
+    'files': ['bin/aserver', 'include/asoundlib.h',
+              'lib64/libatopology.%s' % SHLIB_EXT, 'lib64/libasound.%s' % SHLIB_EXT],
+    'dirs': ['include/alsa', 'lib/pkgconfig', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/r/RStudio/RStudio-2022.02.2-485.eb
+++ b/easybuild/easyconfigs/r/RStudio/RStudio-2022.02.2-485.eb
@@ -1,0 +1,28 @@
+# This easyconfig was created by the BEAR Software team at the University of Birmingham.
+easyblock = 'Tarball'
+
+name = 'RStudio'
+version = '2022.02.2-485'
+
+homepage = "https://www.rstudio.com/"
+description = """RStudio is a set of integrated tools designed to help you be more productive with R."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://download1.rstudio.org/desktop/rhel8/x86_64/']
+sources = [{'filename': '%(namelower)s-%(version)s-x86_64.rpm', 'extract_cmd': 'rpm2cpio %s | cpio -idmv'}]
+checksums = ['ad00e2c52451d6d46a7dd66bc82175aaf349c16e5d50331da7cf57b3400ad256']
+
+dependencies = [('alsa-lib', '1.2.6')]
+
+modextrapaths = {'PATH': 'lib/rstudio/bin'}
+modextravars = {'QMLSCENE_DEVICE': 'softwarecontext'}  # enforce software rendering
+modloadmsg = """\n\nRStudio requires R, but loading this RStudio module does not load R to allow you to select an R to
+load. Please see https://bear-apps.bham.ac.uk/applications/R/ for the available R versions.\n\n"""
+
+sanity_check_paths = {
+    'files': ['lib/rstudio/bin/rstudio'],
+    'dirs': [],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
For INC1202039 - `RStudio-2022.02.2-485.eb`

RStudio also requires a functional X11. One is not added as a dependency as all of the R versions we have will load X11.

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

