### PR TITLE
RELION in 2021a

### DIFF
--- a/easybuild/easyconfigs/c/ctffind/ctffind-4.1.14-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/ctffind/ctffind-4.1.14-foss-2021a.eb
@@ -1,0 +1,48 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Pablo Escobar Lopez
+# sciCORE - University of Basel
+# SIB Swiss Institute of Bioinformatics
+#
+# Author: Ake Sandgren, HPC2N, Umea University
+
+easyblock = 'ConfigureMake'
+
+name = 'ctffind'
+version = '4.1.14'
+
+homepage = 'https://grigoriefflab.umassmed.edu/ctffind4'
+description = """Program for finding CTFs of electron micrographs."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'openmp': True}
+
+source_urls = ['https://grigoriefflab.umassmed.edu/sites/default/files/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = [
+    '%(name)s-%(version)s_asm-fix.patch',
+    '%(name)s-%(version)s_void-functions.patch'
+]
+checksums = [
+    'db17b2ebeb3c3b2b3764e42b820cd50d19ccccf6956c64257bfe5d5ba6b40cb5',  # ctffind-4.1.14.tar.gz
+    'e6d468b3f1569e2d42e077573529dbc3035a03715c436d2349ccaaab63b64f28',  # ctffind-4.1.14_asm-fix.patch
+    '0a578328062881d86b10585f1b0efa81b7a1826baf3e7bcc5c749bba73e96d10',  # ctffind-4.1.14_void-functions.patch
+]
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('libjpeg-turbo', '2.0.6'),
+    ('LibTIFF', '4.2.0'),
+    ('GSL', '2.7'),
+    ('wxWidgets', '3.1.5'),
+]
+
+configopts = '--enable-openmp '
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/ctffind'],
+    'dirs': [],
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/MotionCor2/MotionCor2-1.4.7-GCCcore-10.3.0-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/m/MotionCor2/MotionCor2-1.4.7-GCCcore-10.3.0-CUDA-11.3.1.eb
@@ -1,0 +1,63 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# Author: Ake Sandgren
+# HPC2N
+# Umea University
+easyblock = 'PackedBinary'
+
+name = 'MotionCor2'
+version = '1.4.7'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'https://msg.ucsf.edu/'
+description = """MotionCor2 correct anisotropic image motion at the
+single pixel level across the whole frame, suitable for both single
+particle and tomographic images. Iterative, patch-based motion detection
+is combined with spatial and temporal constraints and dose weighting.
+
+Cite publication: Shawn Q. Zheng, Eugene Palovcak, Jean-Paul Armache,
+Yifan Cheng and David A. Agard (2016) Anisotropic Correction of
+Beam-induced Motion for Improved Single-particle Electron
+Cryo-microscopy, Nature Methods, submitted.
+BioArxiv: https://biorxiv.org/content/early/2016/07/04/061960
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+# No longer directly downloadable, available from https://msg.ucsf.edu/software
+sources = [
+    '%(name)s_%(version)s.zip',
+]
+checksums = ['8c33969b10916835b55f14f3c370f67ebe5c4b2a9df9ec487c5251710f038e6b']
+
+builddependencies = [
+    ('binutils', '2.36.1'),
+]
+
+dependencies = [
+    ('CUDA', '11.3.1', '', True),
+    ('zlib', '1.2.11'),
+    ('libjpeg-turbo', '2.0.6'),
+    ('LibTIFF', '4.2.0'),
+]
+
+# This should be the correct binary for the available CUDA version
+_binary = 'MotionCor2_1.4.7_Cuda113_12-07-2021'
+# Move the correct binary to bin/, create a symlink, and delete all incorrect binaries
+_cmds = [
+    "cd %(installdir)s",
+    "mkdir bin",
+    "mv %s bin/." % _binary,
+    "rm MotionCor2_1.4.7_*",
+    "cd bin",
+    "ln -s %s %%(namelower)s" % _binary,
+]
+postinstallcmds = [' && '.join(_cmds)]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+sanity_check_commands = ["%(namelower)s --help"]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/RELION/RELION-3.0.4_drop_usage_of_mpi_include_path.patch
+++ b/easybuild/easyconfigs/r/RELION/RELION-3.0.4_drop_usage_of_mpi_include_path.patch
@@ -1,0 +1,20 @@
+Don't use include_directories on MPI include paths.
+None of the vars are set anyway when using EB.
+
+Åke Sandgren, 20190426
+diff -ru relion-3.0.4.orig/CMakeLists.txt relion-3.0.4/CMakeLists.txt
+--- relion-3.0.4.orig/CMakeLists.txt    2019-04-03 12:47:22.000000000 +0200
++++ relion-3.0.4/CMakeLists.txt 2019-04-26 08:54:16.441034913 +0200
+@@ -214,12 +214,6 @@
+ # -------------------------------------------------------------------------------MPI--
+ find_package(MPI REQUIRED)
+ 
+-if ("${MPI_CXX_INCLUDE_DIRS}" STREQUAL "")
+-	include_directories("${MPI_CXX_INCLUDE_PATH}")
+-else()
+-	include_directories("${MPI_CXX_INCLUDE_DIRS}")
+-endif()
+-
+ message(STATUS "MPI_INCLUDE_PATH : ${MPI_INCLUDE_PATH}")
+ message(STATUS "MPI_LIBRARIES : ${MPI_LIBRARIES}")
+ message(STATUS "MPI_CXX_INCLUDE_PATH : ${MPI_CXX_INCLUDE_PATH}")

--- a/easybuild/easyconfigs/r/RELION/RELION-3.1.3-foss-2021a-CUDA-11.3.1.eb
+++ b/easybuild/easyconfigs/r/RELION/RELION-3.1.3-foss-2021a-CUDA-11.3.1.eb
@@ -1,0 +1,92 @@
+easyblock = 'CMakeMake'
+
+name = 'RELION'
+version = '3.1.3'
+versionsuffix = '-CUDA-%(cudaver)s'
+
+homepage = 'http://www2.mrc-lmb.cam.ac.uk/relion/index.php/Main_Page'
+description = """RELION (for REgularised LIkelihood OptimisatioN, pronounce rely-on) is a stand-alone computer
+ program that employs an empirical Bayesian approach to refinement of (multiple) 3D reconstructions or 2D class
+ averages in electron cryo-microscopy (cryo-EM)."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'opt': True}
+
+source_urls = ['https://github.com/3dem/relion/archive']
+sources = ['%(version)s.tar.gz']
+patches = [
+    '%(name)s-3.0.4_drop_usage_of_mpi_include_path.patch',
+    '%(name)s-3.0_beta_cuda_capabilities.patch',
+    '%(name)s-%(version)s_add_bham_submit_file_args.patch',
+    ('relion_sbatch.sh', '.'),
+]
+checksums = [
+    'f10934058e0670807b7004899d7b5103c21ad77841219352c66a33f98586d42e',  # 3.1.3.tar.gz
+    # RELION-3.0.4_drop_usage_of_mpi_include_path.patch
+    '5477564782a102e435527573ff0dbd4f8675c948492bb103cfbee92c5c997f83',
+    'aedc0c7e1806094274d8442680aade810943648b08875148f5da226121753a0e',  # RELION-3.0_beta_cuda_capabilities.patch
+    'a39d7b3674a462f06f2d799f12bf51733ab5490451446f9bd63e9391a18cb1fe',  # RELION-3.1.3_add_bham_submit_file_args.patch
+    '648a87b60a441000bda953f648ef00d8a7f0d573900073ff580dc7d98c97df10',  # relion_sbatch.sh
+]
+
+builddependencies = [('CMake', '3.20.1')]
+
+dependencies = [
+    ('CUDA', '11.3.1', '', True),
+    ('X11', '20210518'),
+    ('FLTK', '1.3.6'),
+    ('libpng', '1.6.37'),
+    ('LibTIFF', '4.2.0'),
+    ('tbb', '2020.3'),
+    ('zlib', '1.2.11'),
+    ('ctffind', '4.1.14', versionsuffix),
+    ('MotionCor2', '1.4.7', versionsuffix),
+    ('gnuplot', '5.4.2'),
+    ('tcsh', '6.22.04'),
+    ('ResMap', '1.1.4', '', True),
+]
+
+# Execute commands in the pipeline directly, not through `which`
+local_pipejob_src = '%(builddir)s/%(namelower)s-%(version)s/src/pipeline_jobs.cpp'
+preconfigopts = "sed -i 's/`which \([a-z_]*\)`/\\1/g;s/`//g' %s &&" % local_pipejob_src
+
+local_cuda_compute_capabilities = ['6.0', '7.0', '8.0']
+local_caps = [''.join(x.split('.')) for x in local_cuda_compute_capabilities]
+local_cuda_gencodes = ';'.join(['-gencode arch=compute_%s,code=sm_%s' % (x, x) for x in local_caps])
+local_cuda_arch = "%s" % local_cuda_gencodes
+
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-lpthread' "
+configopts += "-DCUDA=ON -DCudaTexture=ON "
+# multiple CUDA arches - so use the code and patch above to generate
+configopts += "-DCUDA_ARCH='" + local_cuda_arch + "'"
+
+postinstallcmds = [
+    'cp ../%(namelower)s-%(version)s/relion_sbatch.sh %(installdir)s/bin',
+    'chmod +x %(installdir)s/bin/relion_sbatch.sh',
+]
+
+sanity_check_paths = {
+    'files': ['bin/relion', 'bin/relion_refine_mpi'],
+    'dirs': []
+}
+
+sanity_check_commands = ["relion --version"]
+
+modextravars = {
+    'RELION_QSUB_TEMPLATE': '%(installdir)s/bin/relion_sbatch.sh',
+    'RELION_QSUB_COMMAND': 'sbatch',
+    'RELION_ERROR_LOCAL_MPI': '1',
+    'RELION_CTFFIND_EXECUTABLE': 'ctffind',
+    'RELION_MOTIONCOR2_EXECUTABLE': 'motioncor2',
+    'RELION_RESMAP_EXECUTABLE': 'ResMap-1.1.4-linux64',
+    # These will be mapped to XXXextra1XXX from relion_sbatch.sh
+    'RELION_QSUB_EXTRA_COUNT': '3',
+    'RELION_QSUB_EXTRA1': 'Job time limit',
+    'RELION_QSUB_EXTRA1_HELP': 'Set the job time limit.',
+    'RELION_QSUB_EXTRA2': 'Slurm Account / Project code',
+    'RELION_QSUB_EXTRA2_HELP': "Set the slurm project account code.",
+    'RELION_QSUB_EXTRA3': "GPU (e.g. '--gres gpu:1')",
+    'RELION_QSUB_EXTRA3_HELP': "For jobs requiring GPU, set the Slurm: '--gres gpu:1'",
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/RELION/RELION-3.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/r/RELION/RELION-3.1.3-foss-2021a.eb
@@ -1,0 +1,81 @@
+easyblock = 'CMakeMake'
+
+name = 'RELION'
+version = '3.1.3'
+
+homepage = 'http://www2.mrc-lmb.cam.ac.uk/relion/index.php/Main_Page'
+description = """RELION (for REgularised LIkelihood OptimisatioN, pronounce rely-on) is a stand-alone computer
+ program that employs an empirical Bayesian approach to refinement of (multiple) 3D reconstructions or 2D class
+ averages in electron cryo-microscopy (cryo-EM)."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'openmp': True, 'usempi': True, 'opt': True}
+
+source_urls = ['https://github.com/3dem/relion/archive']
+sources = ['%(version)s.tar.gz']
+patches = [
+    '%(name)s-3.0.4_drop_usage_of_mpi_include_path.patch',
+    '%(name)s-3.0_beta_cuda_capabilities.patch',
+    '%(name)s-%(version)s_add_bham_submit_file_args.patch',
+    ('relion_sbatch.sh', '.'),
+]
+checksums = [
+    'f10934058e0670807b7004899d7b5103c21ad77841219352c66a33f98586d42e',  # 3.1.3.tar.gz
+    # RELION-3.0.4_drop_usage_of_mpi_include_path.patch
+    '5477564782a102e435527573ff0dbd4f8675c948492bb103cfbee92c5c997f83',
+    'aedc0c7e1806094274d8442680aade810943648b08875148f5da226121753a0e',  # RELION-3.0_beta_cuda_capabilities.patch
+    'a39d7b3674a462f06f2d799f12bf51733ab5490451446f9bd63e9391a18cb1fe',  # RELION-3.1.3_add_bham_submit_file_args.patch
+    '648a87b60a441000bda953f648ef00d8a7f0d573900073ff580dc7d98c97df10',  # relion_sbatch.sh
+]
+
+builddependencies = [('CMake', '3.20.1')]
+
+dependencies = [
+    ('X11', '20210518'),
+    ('FLTK', '1.3.6'),
+    ('libpng', '1.6.37'),
+    ('LibTIFF', '4.2.0'),
+    ('tbb', '2020.3'),
+    ('zlib', '1.2.11'),
+    ('ctffind', '4.1.14'),
+    ('gnuplot', '5.4.2'),
+    ('tcsh', '6.22.04'),
+    ('ResMap', '1.1.4', '', True),
+]
+
+# Execute commands in the pipeline directly, not through `which`
+local_pipejob_src = '%(builddir)s/%(namelower)s-%(version)s/src/pipeline_jobs.cpp'
+preconfigopts = "sed -i 's/`which \([a-z_]*\)`/\\1/g;s/`//g' %s &&" % local_pipejob_src
+
+configopts = "-DCMAKE_SHARED_LINKER_FLAGS='-lpthread' -DALTCPU=ON "
+configopts += "-DCUDA=OFF -DCudaTexture=OFF "
+
+postinstallcmds = [
+    'cp ../%(namelower)s-%(version)s/relion_sbatch.sh %(installdir)s/bin',
+    'chmod +x %(installdir)s/bin/relion_sbatch.sh',
+]
+
+sanity_check_paths = {
+    'files': ['bin/relion', 'bin/relion_refine_mpi'],
+    'dirs': []
+}
+
+sanity_check_commands = ["relion --version"]
+
+modextravars = {
+    'RELION_QSUB_TEMPLATE': '%(installdir)s/bin/relion_sbatch.sh',
+    'RELION_QSUB_COMMAND': 'sbatch',
+    'RELION_ERROR_LOCAL_MPI': '1',
+    'RELION_CTFFIND_EXECUTABLE': 'ctffind',
+    'RELION_RESMAP_EXECUTABLE': 'ResMap-1.1.4-linux64',
+    # These will be mapped to XXXextra1XXX from relion_sbatch.sh
+    'RELION_QSUB_EXTRA_COUNT': '3',
+    'RELION_QSUB_EXTRA1': 'Job time limit',
+    'RELION_QSUB_EXTRA1_HELP': 'Set the job time limit.',
+    'RELION_QSUB_EXTRA2': 'Slurm Account / Project code',
+    'RELION_QSUB_EXTRA2_HELP': "Set the slurm project account code.",
+    'RELION_QSUB_EXTRA3': "GPU (e.g. '--gres gpu:1')",
+    'RELION_QSUB_EXTRA3_HELP': "For jobs requiring GPU, set the Slurm: '--gres gpu:1'",
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/r/RELION/RELION-3.1.3_add_bham_submit_file_args.patch
+++ b/easybuild/easyconfigs/r/RELION/RELION-3.1.3_add_bham_submit_file_args.patch
@@ -1,0 +1,13 @@
+--- relion-3.1.1.orig/src/pipeline_jobs.cpp	2019-05-07 12:53:25.000000000 +0200
++++ relion-3.1.1/src/pipeline_jobs.cpp	2019-05-11 15:23:09.341930500 +0200
+@@ -558,7 +558,9 @@
+ 		replacing["XXXnameXXX"] = outputname;
+ 		replacing["XXXerrfileXXX"] = outputname + "run.err";
+ 		replacing["XXXoutfileXXX"] = outputname + "run.out";
+-		replacing["XXXqueueXXX"] = joboptions["queuename"].getString();
++       if (!joboptions["queuename"].getString().empty()) {
++           replacing["XXXqosXXX"] = "-q " + joboptions["queuename"].getString();
++       }
+ 		char * extra_count_text = getenv ("RELION_QSUB_EXTRA_COUNT");
+ 		const char extra_count_val = (extra_count_text ? atoi(extra_count_text) : 2);
+ 		for (int i=1; i<=extra_count_val; i++)

--- a/easybuild/easyconfigs/r/RELION/relion_sbatch.sh
+++ b/easybuild/easyconfigs/r/RELION/relion_sbatch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH -J Relion
+#SBATCH -n XXXmpinodesXXX
+#SBATCH -c XXXthreadsXXX
+#SBATCH -e XXXerrfileXXX
+#SBATCH -o XXXoutfileXXX
+#SBATCH XXXqosXXX
+#SBATCH -t XXXextra1XXX
+#SBATCH -A XXXextra2XXX
+#SBATCH XXXextra3XXX
+
+srun XXXcommandXXX

--- a/easybuild/easyconfigs/r/ResMap/ResMap-1.1.4.eb
+++ b/easybuild/easyconfigs/r/ResMap/ResMap-1.1.4.eb
@@ -1,0 +1,22 @@
+easyblock = 'Binary'
+
+name = 'ResMap'
+version = '1.1.4'
+
+homepage = 'http://resmap.sourceforge.net/'
+description = """ResMap (Resolution Map) is a Python (NumPy/SciPy) application with a Tkinter GUI. It is an easy to
+ use software package for computing the local resolution of 3D density maps studied in structural biology, primarily
+ electron cryo-microscopy (cryo-EM)."""
+
+toolchain = SYSTEM
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(name)s-%(version)s-linux64']
+checksums = ['e85c8c535acc284def560d78aaf67dac4a16a1c4c7b46b341e99a3fbe761bd18']
+
+sanity_check_paths = {
+    'files': ['ResMap-1.1.4-linux64'],
+    'dirs': []
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
This is adding RELION to 2021a - based off upstream and existing setup we have on BlueBEAR and Baskerville.

* [x] Assigned to reviewers (usually everyone in apps team)

`RELION-3.1.3-foss-2021a.eb`:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

`RELION-3.1.3-foss-2021a-CUDA-11.3.1.eb`:
* [x] EL8-icelake
* [x] EL8-haswell

