### PR TITLE
fastStructure

### DIFF
--- a/easybuild/easyconfigs/c/Cython/Cython-0.27.3-GCCcore-9.3.0-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.27.3-GCCcore-9.3.0-Python-2.7.18.eb
@@ -1,0 +1,53 @@
+##
+# EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2013 The Cyprus Institute
+# Authors::   Andreas Panteli <a.panteli@cyi.ac.cy>,
+#             Thekla Loizou <t.loizou@cyi.ac.cy>,
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>
+# License::   MIT/GPL
+#
+# Updated: Pavel Grochal (INUITS)
+##
+easyblock = 'PythonPackage'
+
+name = 'Cython'
+version = '0.27.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://cython.org/'
+description = """
+Cython is an optimising static compiler for both the Python programming
+language and the extended Cython programming language (based on Pyrex).
+"""
+docurls = [
+    'https://cython.org/#documentation',
+    'https://github.com/cython/cython',
+]
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['6a00512de1f2e3ce66ba35c5420babaef1fe2d9c43a8faab4080b0dbcc26bc64']
+
+builddependencies = [('binutils', '2.34')]
+
+# Can't use multi_dep because EBPYTHONPREFIXES are not loaded in order.
+# This results in not beeing able to choose Cython version in multi_dep.
+dependencies = [('Python', '2.7.18')]
+
+download_dep_fail = True
+
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/cygdb', 'bin/cython', 'bin/cythonize'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+sanity_check_commands = [
+    'cython --version',
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/c/Cython/Cython-0.27.3-GCCcore-9.3.0-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.27.3-GCCcore-9.3.0-Python-2.7.18.eb
@@ -38,7 +38,7 @@ builddependencies = [('binutils', '2.34')]
 dependencies = [('Python', '2.7.18')]
 
 download_dep_fail = True
-
+sanity_pip_check = True
 use_pip = True
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/f/fastStructure/fastStructure-1.0-foss-2020a-Python-2.7.18.eb
@@ -1,0 +1,57 @@
+# Updated from previous config
+# Author: Pavel Grochal (INUITS)
+# License: GPLv2
+
+name = 'fastStructure'
+version = '1.0'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://rajanil.github.io/fastStructure/'
+description = """
+fastStructure is a fast algorithm for inferring population structure
+from large SNP genotype data. It is based on a variational Bayesian
+framework for posterior inference and is written in Python2.x.
+"""
+docurls = ['https://github.com/rajanil/fastStructure']
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+# https://github.com/rajanil/fastStructure/archive/
+github_account = 'rajanil'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+checksums = ['f1bfb24bb5ecd108bc3a90145fad232012165c1e60608003f1c87d200f867b81']
+
+builddependencies = [
+    # Needs Cython v0.27.3 see:
+    # https://github.com/rajanil/fastStructure/issues/39
+    ('Cython', '0.27.3', versionsuffix),
+]
+
+dependencies = [
+    ('Python', '2.7.18'),
+    ('SciPy-bundle', '2020.03', versionsuffix),
+    ('matplotlib', '2.2.5', versionsuffix),
+    ('GSL', '2.6'),
+]
+
+sanity_check_paths = {
+    'files': [
+        'fastStructure.%s' % SHLIB_EXT,
+        'parse_bed.%s' % SHLIB_EXT,
+        'parse_str.%s' % SHLIB_EXT,
+        'structure.py',
+    ],
+    'dirs': [],
+}
+
+sanity_check_commands = [
+    ('%(installdir)s/structure.py '
+     '-K 3 '
+     '--input=%(installdir)s/test/testdata '
+     '--output=%(builddir)s/testoutput_simple '
+     '--full '
+     '--seed=100'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-foss-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-2.2.5-foss-2020a-Python-2.7.18.eb
@@ -1,0 +1,64 @@
+easyblock = 'PythonBundle'
+
+name = 'matplotlib'
+version = '2.2.5'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'foss', 'version': '2020a'}
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+]
+
+dependencies = [
+    ('Python', '2.7.18'),
+    ('SciPy-bundle', '2020.03', versionsuffix),
+    ('libpng', '1.6.37'),
+    ('freetype', '2.10.1'),
+    ('Tkinter', '%(pyver)s'),
+]
+
+use_pip = True
+sanity_pip_check = True
+
+exts_list = [
+    ('Cycler', '0.10.0', {
+        'modulename': 'cycler',
+        'source_tmpl': 'cycler-%(version)s.tar.gz',
+        'checksums': ['cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8'],
+    }),
+    ('subprocess32', '3.5.4', {
+        'checksums': ['eb2937c80497978d181efa1b839ec2d9622cf9600a039a79d0e108d1f9aec79d'],
+    }),
+    ('backports.functools_lru_cache', '1.6.1', {
+        'checksums': ['8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a'],
+    }),
+    ('kiwisolver', '1.1.0', {
+        'checksums': ['53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75'],
+    }),
+    (name, version, {
+        'prebuildopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'preinstallopts': "export CPLUS_INCLUDE_PATH=$EBROOTFREETYPE/include/freetype2:${CPLUS_INCLUDE_PATH} && ",
+        'checksums': ['a3037a840cd9dfdc2df9fee8af8f76ca82bfab173c0f9468193ca7a89a2b60ea'],
+    }),
+]
+
+postinstallcmds = [
+    'touch %(installdir)s/lib/python%(pyshortver)s/site-packages/mpl_toolkits/__init__.py',
+]
+
+sanity_check_commands = [
+    """python -c 'import matplotlib; matplotlib.use("TkAgg"); import matplotlib.pyplot' """,
+    "python -c 'from mpl_toolkits.mplot3d import Axes3D'",
+]
+
+# use non-interactive plotting backend as default
+# see https://matplotlib.org/tutorials/introductory/usage.html#what-is-a-backend
+modextravars = {'MPLBACKEND': 'Agg'}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-2.7.18.eb
+++ b/easybuild/easyconfigs/s/SciPy-bundle/SciPy-bundle-2020.03-foss-2020a-Python-2.7.18.eb
@@ -25,7 +25,12 @@ exts_list = [
         'checksums': ['e5cf3fdf13401885e8eea8170624ec96225e2174eb0c611c6f26dd33b489e3ff'],
     }),
     ('scipy', '1.2.3', {
-        'checksums': ['ecbe6413ca90b8e19f8475bfa303ac001e81b04ec600d17fa7f816271f7cca57'],
+        'patches': ['scipy-1.2.3_fix_nan_problem_in_vi.patch'],
+        'checksums': [
+            'ecbe6413ca90b8e19f8475bfa303ac001e81b04ec600d17fa7f816271f7cca57',  # scipy-1.2.3.tar.gz
+            # scipy-1.2.3_fix_nan_problem_in_vi.patch
+            '0513c5d0491a3f062ed024b6aa7b382706e8c42b3a3fdd26ff7a4d305ac9a30d',
+        ],
     }),
     ('mpi4py', '3.0.3', {
         'checksums': ['012d716c8b9ed1e513fcc4b18e5af16a8791f51e6d1716baccf988ad355c5a1f'],

--- a/easybuild/easyconfigs/s/SciPy-bundle/scipy-1.2.3_fix_nan_problem_in_vi.patch
+++ b/easybuild/easyconfigs/s/SciPy-bundle/scipy-1.2.3_fix_nan_problem_in_vi.patch
@@ -1,0 +1,21 @@
+MAINT: special: add an explicit NaN check for `iv` arguments
+
+Taken from https://github.com/scipy/scipy/pull/10675
+
+This fixes a problem with test_nan_inputs[iv] when running on SkylakeX
+
+Åke Sandgren, 2021-04-08
+diff -ru scipy-1.2.3.orig/scipy/special/cephes/scipy_iv.c scipy-1.2.3/scipy/special/cephes/scipy_iv.c
+--- scipy-1.2.3.orig/scipy/special/cephes/scipy_iv.c	2020-01-20 21:44:32.000000000 +0100
++++ scipy-1.2.3/scipy/special/cephes/scipy_iv.c	2021-04-08 17:12:12.615806427 +0200
+@@ -82,6 +82,10 @@
+     int sign;
+     double t, ax, res;
+ 
++    if (npy_isnan(v) || npy_isnan(x)) {
++        return NPY_NAN;
++    }
++
+     /* If v is a negative integer, invoke symmetry */
+     t = floor(v);
+     if (v < 0.0) {

--- a/easybuild/easyconfigs/t/Tkinter/Tkinter-2.7.18-GCCcore-9.3.0.eb
+++ b/easybuild/easyconfigs/t/Tkinter/Tkinter-2.7.18-GCCcore-9.3.0.eb
@@ -1,0 +1,22 @@
+name = 'Tkinter'
+version = '2.7.18'
+
+homepage = 'https://python.org/'
+description = """Tkinter module, built with the Python buildsystem"""
+
+toolchain = {'name': 'GCCcore', 'version': '9.3.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://www.python.org/ftp/python/%(version)s/']
+sources = ['Python-%(version)s.tgz']
+checksums = ['da3080e3b488f648a3d7a4560ddee895284c3380b11d6de75edb986526b9a814']
+
+builddependencies = [('binutils', '2.34')]
+
+dependencies = [
+    ('Python', version),
+    ('Tk', '8.6.10'),
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'lang'


### PR DESCRIPTION
For INC1258507 - `fastStructure-1.0-foss-2020a-Python-2.7.18.eb` - based off the upstream for an earlier toolchain and pull in the SciPy patch

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-cascadelake
* [x] EL8-haswell
* [x] Ubuntu20 VM
