### PR TITLE
nlopt python config

### DIFF
--- a/easybuild/easyconfigs/n/NLopt/NLopt-2.7.0-foss-2021a-Python.eb
+++ b/easybuild/easyconfigs/n/NLopt/NLopt-2.7.0-foss-2021a-Python.eb
@@ -1,0 +1,45 @@
+easyblock = 'CMakeMake'
+
+name = 'NLopt'
+version = '2.7.0'
+versionsuffix = '-Python'
+
+homepage = 'http://ab-initio.mit.edu/wiki/index.php/NLopt'
+description = """ NLopt is a free/open-source library for nonlinear optimization,
+ providing a common interface for a number of different free optimization routines
+ available online as well as original implementations of various other algorithms. """
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/stevengj/nlopt/archive']
+sources = ['v%(version)s.tar.gz']
+checksums = ['b881cc2a5face5139f1c5a30caf26b7d3cb43d69d5e423c9d78392f99844499f']
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+    ('binutils', '2.36.1'),
+]
+
+dependencies = [
+    ('Python', '3.9.5'),
+    ('SciPy-bundle', '2021.05'),
+    ('SWIG', '4.0.2'),
+    ('Guile', '2.2.7'),
+]
+
+configopts = [
+    '-DBUILD_SHARED_LIBS=ON',
+    '-DBUILD_SHARED_LIBS=OFF'
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+sanity_check_paths = {
+    'files': ['lib/libnlopt.a', 'lib/libnlopt.%s' % SHLIB_EXT, 'include/nlopt.h'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+sanity_check_commands = ['python -c "import %(namelower)s"']
+
+moduleclass = 'numlib'


### PR DESCRIPTION
For INC1266335 - `NLopt-2.7.0-foss-2021a-Python.eb`

This is for a Python equivalent of `NLopt-2.7.0-GCCcore-10.3.0.eb`. Not sure whether the versionsuffix is appropriate though, given that it may cause confusion with earlier Python module naming schemes?

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell
