### PR TITLE
CESM 2.1.3

### DIFF
--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -3,7 +3,7 @@ easyblock = 'Tarball'
 name = 'CESM'
 version = '2.1.3'
 
-homepage = 'http://www.cesm.ucar.edu/models/cesm2/'
+homepage = 'https://www.cesm.ucar.edu/models/cesm2/'
 description = """The Community Earth System Model (CESM) is a fully-coupled, global climate model that provides
  state-of-the-art computer simulations of the Earth's past, present, and future climate states."""
 

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -12,9 +12,9 @@ toolchain = {'name': 'foss', 'version': '2021a'}
 source_urls = ['https://github.com/ESCOMP/cesm/archive/']
 sources = [
     'release-%(namelower)s%(version)s.tar.gz',
-    {'filename':'bluebear_config_batch.xml','extract_cmd':'cp %s .'},
-    {'filename':'bluebear_config_compilers.xml','extract_cmd':'cp %s .'},
-    {'filename':'bluebear_config_machines.xml','extract_cmd':'cp %s .'},
+    {'filename': 'bluebear_config_batch.xml', 'extract_cmd': 'cp %s .'},
+    {'filename': 'bluebear_config_compilers.xml', 'extract_cmd': 'cp %s .'},
+    {'filename': 'bluebear_config_machines.xml', 'extract_cmd': 'cp %s .'},
 ]
 checksums = [
     '6adae8b9cc74afdf002582fcb66a53942dcfcac94601fe5d1356d355851eb479',  # release-cesm2.1.3.tar.gz
@@ -53,8 +53,8 @@ dependencies = [
 
 sanity_check_paths = {
     'files': ['Externals.cfg'],
-    'dirs': ['cime/scripts', 'components/cam', 'components/cice', 'components/cism', 'components/clm', 
-    		'components/mosart', 'components/pop', 'components/rtm', 'components/ww3']
+    'dirs': ['cime/scripts', 'components/cam', 'components/cice', 'components/cism', 'components/clm',
+             'components/mosart', 'components/pop', 'components/rtm', 'components/ww3']
 }
 
 modextrapaths = {'PATH': 'cime/scripts'}

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -59,4 +59,7 @@ sanity_check_paths = {
 
 modextrapaths = {'PATH': 'cime/scripts'}
 
+modloadmsg = """Make sure the $CESMDATAROOT, $DIN_LOC_ROOT and $CIME_OUTPUT_ROOT environment variables have been set.
+"""
+
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -1,0 +1,62 @@
+easyblock = 'Tarball'
+
+name = 'CESM'
+version = '2.1.3'
+
+homepage = 'http://www.cesm.ucar.edu/models/cesm2/'
+description = """The Community Earth System Model (CESM) is a fully-coupled, global climate model that provides
+ state-of-the-art computer simulations of the Earth's past, present, and future climate states."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+
+source_urls = ['https://github.com/ESCOMP/cesm/archive/']
+sources = [
+    'release-%(namelower)s%(version)s.tar.gz',
+    {'filename':'bluebear_config_batch.xml','extract_cmd':'cp %s .'},
+    {'filename':'bluebear_config_compilers.xml','extract_cmd':'cp %s .'},
+    {'filename':'bluebear_config_machines.xml','extract_cmd':'cp %s .'},
+]
+checksums = [
+    '6adae8b9cc74afdf002582fcb66a53942dcfcac94601fe5d1356d355851eb479',  # release-cesm2.1.3.tar.gz
+    'e6734909a9c9edb47ae81868282a81ff634dc0fde36a7b6b8e85f894fecf5571',  # bluebear_config_batch.xml
+    '840af4d92789edb4ddfd3d5fefd2c90ec0ee7b549f5cdfad533a02bfd40ef5eb',  # bluebear_config_compilers.xml
+    '35f03e646fa2c71df8bf8ca8599d4ccbdad9d3695eb634c07164f8747759a2cf',  # bluebear_config_machines.xml
+]
+
+postinstallcmds = [
+    # accept server certificate
+	('svn --non-interactive --trust-server-cert list '
+     'https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_0_rel_08/components/cam; '
+     'cd %(installdir)s; ./manage_externals/checkout_externals'),
+	'cp %(builddir)s/bluebear_config_machines.xml %(installdir)s/cime/config/cesm/machines/config_machines.xml',
+	'cp %(builddir)s/bluebear_config_batch.xml %(installdir)s/cime/config/cesm/machines/config_batch.xml',
+	'cp %(builddir)s/bluebear_config_compilers.xml %(installdir)s/cime/config/cesm/machines/config_compilers.xml',
+    # necessary forward slash is missing in version 2.1.3
+    # https://bb.cgd.ucar.edu/cesm/threads/porting-to-a-local-machine-cant-automatically-download-the-input-data.5608
+    ('sed -i s%ftp://ftp.cgd.ucar.edu/cesm/inputdata%ftp://ftp.cgd.ucar.edu/cesm/inputdata/% '
+     '%(installdir)s/cime/config/cesm/config_inputdata.xml'),
+]
+
+dependencies = [
+    ('CMake', '3.20.1'),
+    ('Python', '3.9.5'),
+    ('Perl', '5.32.1'),
+    ('XML-LibXML', '2.0207'),
+    ('ESMF', '8.1.1'),
+    ('netCDF', '4.8.0'),
+    ('netCDF-Fortran', '4.5.3'),
+    ('netCDF-C++4', '4.3.1'),
+    ('PnetCDF', '1.12.2'),
+    ('git', '2.32.0', '-nodocs'),
+    ('Subversion', '1.14.1'),
+]
+
+sanity_check_paths = {
+    'files': ['Externals.cfg'],
+    'dirs': ['cime/scripts', 'components/cam', 'components/cice', 'components/cism', 'components/clm', 
+    		'components/mosart', 'components/pop', 'components/rtm', 'components/ww3']
+}
+
+modextrapaths = {'PATH': 'cime/scripts'}
+
+moduleclass = 'geo'

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -24,7 +24,7 @@ checksums = [
 ]
 
 postinstallcmds = [
-    # accept server certificate
+    # accept server certificate and run checkout_externals script
     ('svn --non-interactive --trust-server-cert list '
      'https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_0_rel_08/components/cam; '
      'cd %(installdir)s; ./manage_externals/checkout_externals'),

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -25,12 +25,12 @@ checksums = [
 
 postinstallcmds = [
     # accept server certificate
-	('svn --non-interactive --trust-server-cert list '
+    ('svn --non-interactive --trust-server-cert list '
      'https://svn-ccsm-models.cgd.ucar.edu/cam1/release_tags/cam_cesm2_0_rel_08/components/cam; '
      'cd %(installdir)s; ./manage_externals/checkout_externals'),
-	'cp %(builddir)s/bluebear_config_machines.xml %(installdir)s/cime/config/cesm/machines/config_machines.xml',
-	'cp %(builddir)s/bluebear_config_batch.xml %(installdir)s/cime/config/cesm/machines/config_batch.xml',
-	'cp %(builddir)s/bluebear_config_compilers.xml %(installdir)s/cime/config/cesm/machines/config_compilers.xml',
+    'cp %(builddir)s/bluebear_config_machines.xml %(installdir)s/cime/config/cesm/machines/config_machines.xml',
+    'cp %(builddir)s/bluebear_config_batch.xml %(installdir)s/cime/config/cesm/machines/config_batch.xml',
+    'cp %(builddir)s/bluebear_config_compilers.xml %(installdir)s/cime/config/cesm/machines/config_compilers.xml',
     # necessary forward slash is missing in version 2.1.3
     # https://bb.cgd.ucar.edu/cesm/threads/porting-to-a-local-machine-cant-automatically-download-the-input-data.5608
     ('sed -i s%ftp://ftp.cgd.ucar.edu/cesm/inputdata%ftp://ftp.cgd.ucar.edu/cesm/inputdata/% '

--- a/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/c/CESM/CESM-2.1.3-foss-2021a.eb
@@ -59,7 +59,8 @@ sanity_check_paths = {
 
 modextrapaths = {'PATH': 'cime/scripts'}
 
-modloadmsg = """Make sure the $CESMDATAROOT, $DIN_LOC_ROOT and $CIME_OUTPUT_ROOT environment variables have been set.
+modloadmsg = """Make sure the $CESMDATAROOT, $DIN_LOC_ROOT and $CIME_OUTPUT_ROOT environment variables have been set
+before attempting to set up a case.
 """
 
 moduleclass = 'geo'

--- a/easybuild/easyconfigs/c/CESM/bluebear_config_batch.xml
+++ b/easybuild/easyconfigs/c/CESM/bluebear_config_batch.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<config_batch version="2.1">
+  <!--
+     File:    config_batch.xml
+     Purpose: abstract out the parts of run scripts that are different, and use this configuration to
+     create cesm run scripts from a single template.
+
+     batch_system:     the batch system type and version
+     batch_query:      the batch query command for each batch system.
+     batch_redirect:   Whether a redirect character is needed to submit jobs.
+     batch_directive:  The string that prepends a batch directive for the batch system.
+     jobid_pattern:    A perl regular expression used to filter out the returned job id from a
+                       queue submission.
+
+ ===============================================================
+ batch_system
+ ===============================================================
+ The batch_system and associated tags are meant for configuring batch systems and
+ queues across machines.  The batch_system tag denotes the name for a particular
+ batch system, these can either be shared between one or more machines, or can be
+ defined for a specific machine if need be.
+
+ Machine specific entries take precidence over generic entries, directives are appended
+
+ queues:
+ one or more queues can be defined per batch_system. if the attribute default="true"
+ is used, then that queue will be used by default. Alternatively, multiple queues can
+ be used.  The following variables can be used to choose a queue :
+ walltimemin: Giving the minimum amount of walltime for the queue.
+ walltimemax: The maximum amount of walltime for a queue.
+ nodemin:      The minimum node count required to use this queue.
+ nodemax:      The maximum node count required to use this queue.
+ jobmin:      The minimum task count required to use this queue. This should only rarely be used to select queues that only use a fraction of a node. This cannot be used in conjuction with nodemin.
+ jobmax:      The maximum task count required to use this queue. This should only rarely be used to select queues that only use a fraction of a node. This cannot be used in conjuction with nodemax.
+    -->
+  <batch_system type="template" >
+    <batch_query args=""></batch_query>
+    <batch_submit></batch_submit>
+    <batch_redirect></batch_redirect>
+    <batch_directive></batch_directive>
+    <directives>
+      <directive></directive>
+    </directives>
+  </batch_system>
+
+  <batch_system type="none" >
+    <batch_query args=""></batch_query>
+    <batch_submit></batch_submit>
+    <batch_redirect></batch_redirect>
+    <batch_directive></batch_directive>
+    <directives>
+      <directive></directive>
+    </directives>
+  </batch_system>
+  
+  <batch_system type="slurm" >
+    <batch_query per_job_arg="-j">squeue</batch_query>
+    <batch_cancel>scancel</batch_cancel>
+    <batch_directive>#SBATCH</batch_directive>
+    <jobid_pattern>(\d+)$</jobid_pattern>
+    <depend_string> --dependency=afterok:jobid</depend_string>
+    <depend_allow_string> --dependency=afterany:jobid</depend_allow_string>
+    <depend_separator>,</depend_separator>
+    <walltime_format>%H:%M:%S</walltime_format>
+    <batch_mail_flag>--mail-user</batch_mail_flag>
+    <batch_mail_type_flag>--mail-type</batch_mail_type_flag>
+    <batch_mail_type>none, all, begin, end, fail</batch_mail_type>
+    <directives>
+      <directive> --job-name={{ job_id }}</directive>
+      <directive> --nodes={{ num_nodes }}</directive>
+      <directive> --ntasks-per-node={{ tasks_per_node }}</directive>
+      <directive> --output={{ job_id }}   </directive>
+      <directive> --exclusive                        </directive>
+    </directives>
+  </batch_system>
+
+  <batch_system type="slurm" MACH="bluebear">
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="--qos" name="$JOB_QUEUE"/>
+      <arg flag="--account" name="$PROJECT"/>
+    </submit_args>
+    <queues>
+      <queue default="true" walltimemax="240:00:00">bbdefault</queue>
+      <queue walltimemax="00:10:00">bbshort</queue>
+    </queues>
+  </batch_system>
+</config_batch>

--- a/easybuild/easyconfigs/c/CESM/bluebear_config_compilers.xml
+++ b/easybuild/easyconfigs/c/CESM/bluebear_config_compilers.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config_compilers version="2.0">
+<!--
+========================================================================
+This file defines compiler flags for building CESM.  General flags are listed first
+followed by flags specific to particular operating systems, followed by particular machines.
+
+More general flags are replaced by more specific flags.
+
+Attributes indicate that an if clause should be added to the Macros so that these flags are added
+only under the conditions described by the attribute(s).
+
+The env_mach_specific file may set environment variables or load modules which set environment variables
+which are then  used in the Makefile.   For example the NETCDF_PATH on many machines is set by a module.
+
+========================================================================
+Serial/MPI compiler specification
+========================================================================
+
+SCC   and  SFC specifies the serial compiler
+MPICC and  MPICC specifies the mpi compiler
+
+if $MPILIB is set to mpi-serial then
+CC = $SCC
+FC = $SFC
+MPICC = $SCC
+MPIFC = $SFC
+INC_MPI = $(CIMEROOT)/src/externals/mct/mpi-serial
+
+========================================================================
+Options for including C++ code in the build
+========================================================================
+
+SUPPORTS_CXX (TRUE/FALSE): Whether we have defined all the necessary
+settings for including C++ code in the build for this compiler (or
+this compiler/machine combination). See below for a description of the
+necessary settings.
+
+The following are required for a compiler to support the inclusion of
+C++ code:
+
+SCXX: serial C++ compiler
+
+MPICXX: mpi C++ compiler
+
+CXX_LINKER (CXX/FORTRAN): When C++ code is included in the build, do
+we use a C++ or Fortran linker?
+
+In addition, some compilers require additional libraries or link-time
+flags, specified via CXX_LIBS or CXX_LDFLAGS, as in the following
+examples:
+
+<CXX_LIBS> -L/path/to/directory -lfoo </CXX_LIBS>
+
+or
+
+<CXX_LDFLAGS> -cxxlib </CXX_LDFLAGS>
+
+Note that these libraries or LDFLAGS will be added on the link line,
+regardless of whether we are using a C++ or Fortran linker. For
+example, if CXX_LINKER=CXX, then the above CXX_LIBS line should
+specify extra libraries needed when linking C++ and fortran code using
+a C++ linker. If CXX_LINKER=FORTRAN, then the above CXX_LDFLAGS line
+should specify extra LDFLAGS needed when linking C++ and fortran code
+using a fortran linker.
+
+-->
+<!-- Define default values that can be overridden by specific
+     compilers -->
+<compiler>
+  <CPPDEFS>
+    <append MODEL="pop"> -D_USE_FLOW_CONTROL </append>
+  </CPPDEFS>
+  <SUPPORTS_CXX>FALSE</SUPPORTS_CXX>
+</compiler>
+
+<compiler COMPILER="gnu">
+  <CFLAGS>
+    <base> -std=gnu99 </base>
+    <append compile_threaded="true"> -fopenmp </append>
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=invalid,zero,overflow -fcheck=bounds </append>
+    <append DEBUG="FALSE"> -O </append>
+  </CFLAGS>
+  <CPPDEFS>
+    <!-- http://gcc.gnu.org/onlinedocs/gfortran/ -->
+    <append> -DFORTRANUNDERSCORE -DNO_R16 -DCPRGNU</append>
+  </CPPDEFS>
+  <CXX_LINKER>FORTRAN</CXX_LINKER>
+  <FC_AUTO_R8>
+    <base> -fdefault-real-8 </base>
+  </FC_AUTO_R8>
+  <FFLAGS>
+    <!-- -ffree-line-length-none and -ffixed-line-length-none need to be in FFLAGS rather than in FIXEDFLAGS/FREEFLAGS
+       so that these are passed to cmake builds (cmake builds don't use FIXEDFLAGS and FREEFLAGS). -->
+    <base>  -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none </base>
+    <append compile_threaded="true"> -fopenmp </append>
+    <!-- Ideally, we would also have 'invalid' in the ffpe-trap list. But at
+         least with some versions of gfortran (confirmed with 5.4.0, 6.3.0 and
+         7.1.0), gfortran's isnan (which is called in cime via the
+         CPRGNU-specific shr_infnan_isnan) causes a floating point exception
+         when called on a signaling NaN. -->
+    <append DEBUG="TRUE"> -g -Wall -Og -fbacktrace -ffpe-trap=zero,overflow -fcheck=bounds </append>
+    <append DEBUG="FALSE"> -O </append>
+  </FFLAGS>
+  <FFLAGS_NOOPT>
+    <base> -O0 </base>
+  </FFLAGS_NOOPT>
+  <FIXEDFLAGS>
+    <base>  -ffixed-form </base>
+  </FIXEDFLAGS>
+  <FREEFLAGS>
+    <base> -ffree-form </base>
+  </FREEFLAGS>
+  <HAS_F2008_CONTIGUOUS>FALSE</HAS_F2008_CONTIGUOUS>
+  <LDFLAGS>
+    <append compile_threaded="true"> -fopenmp </append>
+  </LDFLAGS>
+  <MPICC> mpicc  </MPICC>
+  <MPICXX> mpicxx </MPICXX>
+  <MPIFC> mpif90 </MPIFC>
+  <SCC> gcc </SCC>
+  <SCXX> g++ </SCXX>
+  <SFC> gfortran </SFC>
+  <SUPPORTS_CXX>TRUE</SUPPORTS_CXX>
+</compiler>
+
+<compiler COMPILER="gnu" MACH="bluebear">
+  <FFLAGS>
+    <append> -fallow-argument-mismatch -fallow-invalid-boz </append>
+  </FFLAGS>
+  <SLIBS>
+    <append> -L$(NETCDF_PATH)/lib -lnetcdf -L$(NETCDF_FORTRAN_PATH)/lib -lnetcdff </append>
+  </SLIBS>
+</compiler>
+</config_compilers>

--- a/easybuild/easyconfigs/c/CESM/bluebear_config_machines.xml
+++ b/easybuild/easyconfigs/c/CESM/bluebear_config_machines.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0"?>
+
+<!--
+
+===============================================================
+COMPILER and COMPILERS
+===============================================================
+If a machine supports multiple compilers - then
+- the settings for COMPILERS should reflect the supported compilers
+as a comma separated string
+- the setting for COMPILER should be the default compiler
+(which is one of the values in COMPILERS)
+
+===============================================================
+MPILIB and MPILIBS
+===============================================================
+If a machine supports only one MPILIB is supported - then
+the setting for  MPILIB and MPILIBS should be blank ("")
+If a machine supports multiple mpi libraries (e.g. mpich and openmpi)
+- the settings for MPILIBS should reflect the supported mpi libraries
+as a comma separated string
+
+The default settings for COMPILERS and MPILIBS is blank (in config_machines.xml)
+
+Normally variable substitutions are not made until the case scripts are run, however variables
+of the form $ENV{VARIABLE_NAME} are substituted in create_newcase from the environment
+variable of the same name if it exists.
+
+===============================================================
+PROJECT_REQUIRED
+===============================================================
+A machine may need the PROJECT xml variable to be defined either because it is
+used in some paths, or because it is used to give an account number in the job
+submission script. If either of these are the case, then PROJECT_REQUIRED
+should be set to TRUE for the given machine.
+
+
+mpirun: the mpirun command that will be used to actually launch the model.
+The attributes used to choose the mpirun command are:
+
+mpilib: can either be 'default' the name of an mpi library, or a compiler name so one can choose the mpirun
+based on the mpi library in use.
+
+the 'executable' tag must have arguments required for the chosen mpirun, as well as the executable name.
+
+unit_testing: can be 'true' or 'false'.
+This allows using a different mpirun command to launch unit tests
+
+-->
+
+<config_machines version="2.0">
+  <machine MACH="bluebear">
+      <DESC> BlueBEAR supercomputer, University of Birmingham </DESC>
+      <OS>LINUX</OS>
+      <COMPILERS>gnu</COMPILERS>
+      <MPILIBS>openmpi</MPILIBS>
+      <CIME_OUTPUT_ROOT>$ENV{CIME_OUTPUT_ROOT}</CIME_OUTPUT_ROOT>
+      <DIN_LOC_ROOT>$ENV{DIN_LOC_ROOT}</DIN_LOC_ROOT>
+      <DIN_LOC_ROOT_CLMFORC>$DIN_LOC_ROOT</DIN_LOC_ROOT_CLMFORC>
+      <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+      <BASELINE_ROOT>$CIME_OUTPUT_ROOT/cesm_baselines</BASELINE_ROOT>
+      <CCSM_CPRNC>$ENV{EBROOTCESM}/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+      <GMAKE_J>8</GMAKE_J>
+      <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+      <SUPPORTED_BY>bear-rsg@contacts.bham.ac.uk</SUPPORTED_BY>
+      <MAX_TASKS_PER_NODE>72</MAX_TASKS_PER_NODE>
+      <MAX_MPITASKS_PER_NODE>72</MAX_MPITASKS_PER_NODE>
+      <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+      <mpirun mpilib="openmpi">
+        <executable>mpirun</executable>
+        <arguments>
+            <arg name="num_tasks"> -np {{ total_tasks }}</arg>
+        </arguments>
+      </mpirun>
+      <module_system type="module" allow_error="true">
+      <init_path lang="perl">$LMOD_ROOT/$LMOD_VERSION/init/perl</init_path>
+      <init_path lang="python">$LMOD_ROOT/$LMOD_VERSION/init/env_modules_python.py</init_path>
+      <init_path lang="sh">$LMOD_ROOT/$LMOD_VERSION/init/sh</init_path>
+      <init_path lang="csh">$LMOD_ROOT/$LMOD_VERSION/init/csh</init_path>
+      <cmd_path lang="perl">$LMOD_ROOT/$LMOD_VERSION/libexec/lmod perl</cmd_path>
+      <cmd_path lang="python">$LMOD_ROOT/$LMOD_VERSION/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+          <command name="purge"/>
+      </modules>
+      <modules>
+          <command name="load">bluebear</command>
+      </modules>
+      <modules compiler="gnu">
+        <command name="load">CESM/2.1.3-foss-2021a</command>
+      </modules>
+    </module_system>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="TMPDIR">/scratch/$USER</env>
+      <env name="NETCDF_PATH">$ENV{EBROOTNETCDF}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{EBROOTNETCDFMINFORTRAN}</env>
+      <env name="NETCDF_C_PATH">$ENV{EBROOTNETCDFMINCPLUSPLUS4}</env>
+      <env name="PNETCDF_PATH">$ENV{EBROOTPNETCDF}</env>
+      <env name="ESMF_LIBDIR">$ENV{EBROOTESMF}/lib</env>
+      <env name="CESMDATAROOT">$ENV{CESMDATAROOT}</env>
+    </environment_variables>
+  </machine>
+
+  <default_run_suffix>
+    <default_run_exe>${EXEROOT}/cesm.exe </default_run_exe>
+    <default_run_misc_suffix> >> cesm.log.$LID 2>&amp;1 </default_run_misc_suffix>
+  </default_run_suffix>
+
+</config_machines>

--- a/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0207-GCCcore-10.3.0.eb
+++ b/easybuild/easyconfigs/x/XML-LibXML/XML-LibXML-2.0207-GCCcore-10.3.0.eb
@@ -1,0 +1,56 @@
+easyblock = 'Bundle'
+
+name = 'XML-LibXML'
+version = '2.0207'
+
+homepage = 'https://metacpan.org/pod/distribution/XML-LibXML/LibXML.pod'
+description = "Perl binding for libxml2"
+
+toolchain = {'name': 'GCCcore', 'version': '10.3.0'}
+
+builddependencies = [
+    ('pkg-config', '0.29.2'),
+    ('binutils', '2.36.1'),
+]
+
+dependencies = [
+    ('Perl', '5.32.1'),
+    ('libxml2', '2.9.10'),
+]
+
+exts_defaultclass = 'PerlModule'
+exts_filter = ("perldoc -lm %(ext_name)s ", "")
+
+exts_list = [
+    ('File::chdir', '0.1010', {
+        'source_tmpl': 'File-chdir-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN'],
+        'checksums': ['efc121f40bd7a0f62f8ec9b8bc70f7f5409d81cd705e37008596c8efc4452b01'],
+    }),
+    ('Alien::Base', '2.41', {
+        'source_tmpl': 'Alien-Build-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/'],
+        'checksums': ['aaa738117131b016f17f103b167deae2588f03bb72aa3fe15cbb1bad344cf2a4'],
+    }),
+    ('Alien::Libxml2', '0.17', {
+        'source_tmpl': 'Alien-Libxml2-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/P/PL/PLICEASE'],
+        'checksums': ['73b45244f0b5c36e5332c33569b82a1ab2c33e263f1d00785d2003bcaec68db3'],
+    }),
+    ('XML::LibXML', version, {
+        'source_tmpl': 'XML-LibXML-%(version)s.tar.gz',
+        'source_urls': ['https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/'],
+        'checksums': ['903436c9859875bef5593243aae85ced329ad0fb4b57bbf45975e32547c50c15'],
+    }),
+]
+
+modextrapaths = {
+    'PERL5LIB': 'lib/perl5/site_perl/%(perlver)s/',
+}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/perl5/site_perl/%(perlver)s/%(arch)s-linux-thread-multi/XML/LibXML'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
For DASP/INC1240404 - `CESM-2.1.3-foss-2021a.eb`

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [ ] EL8-icelake
* [ ] EL8-cascadelake
* [ ] EL8-haswell


Used https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/c/CESM-deps/CESM-deps-2-foss-2018b.eb and https://github.com/ComputeCanada/easybuild-easyconfigs/blob/computecanada-main/easybuild/easyconfigs/c/cesm/cesm-2.1.3.eb as a starting point.

Example usage for a non-standard QOS (run the following in a slurm job using, e.g., 8 cores; this will then build the case and submit further slurm jobs to run the case):
```
create_newcase --case test_waccmx --res f19_f19 --compset FXHIST --mach bluebear -q <QOS> --project <PROJECT> --walltime 4:0:0 --run-unsupported
cd test_waccmx
./case.setup
./xmlchange NTASKS=72 --subgroup=case.run
./xmlchange GMAKE_J=$SLURM_NTASKS
./xmlchange JOB_QUEUE=<QOS> --subgroup=case.st_archive --force
./xmlchange NTASKS=1 --subgroup=case.st_archive
./xmlchange JOB_WALLCLOCK_TIME=0:10:0 --subgroup=case.st_archive
./case.build
./case.submit
```

The `$CESMDATAROOT`, `$DIN_LOC_ROOT` and `$CIME_OUTPUT_ROOT` environment variables will also need to be set by the user.