### PR TITLE
ChAMP-meta

### DIFF
--- a/easybuild/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2020a-foss-2020a-R-4.0.0.eb
+++ b/easybuild/easyconfigs/b/BEAR-R-bio/BEAR-R-bio-2020a-foss-2020a-R-4.0.0.eb
@@ -34,6 +34,7 @@ dependencies = [
     ('M3C', '1.10.0', versionsuffix),
     ('kinship2', '1.8.5', versionsuffix),
     ('qtl2', '0.28', versionsuffix),
+    ('ChAMP', '2.18.3', versionsuffix),
 ]
 
 moduleclass = 'bio'


### PR DESCRIPTION
For INC1309155 - `BEAR-R-bio-2020a-foss-2020a-R-4.0.0.eb`

__ChAMP added to R Bio meta module so user can access from Portal__

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-cascadelake
* [x] EL8-haswell