### PR TITLE
dealii9.4 foss & intel builds

### DIFF
--- a/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-foss-2021a.eb
@@ -10,9 +10,7 @@ description = """A C++ software library supporting the creation of finite elemen
 toolchain = {'name': 'foss', 'version': '2021a'}
 toolchainopts = {'usempi': True, 'pic': True, 'strict': True}
 
-source_urls = [
-    'https://www.dealii.org/downloads/',
-    ]
+source_urls = ['https://www.dealii.org/downloads/']
 sources = ['dealii-%(version)s.tar.gz']
 checksums = ['238677006cd9173658e5b69cdd1861f800556982db6005a3cc5eb8329cc1e36c']
 
@@ -29,6 +27,7 @@ dependencies = [
     ('TXR', '273'),
 ]
 
+# disable the affinity test, as it expects access to all cores
 preconfigopts = """sed -i 's/make_quicktest("affinity/#/' ../dealii-%(version)s/tests/quick_tests/CMakeLists.txt && """
 
 configopts = '-DDEAL_II_WITH_MPI=ON '

--- a/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-foss-2021a.eb
+++ b/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-foss-2021a.eb
@@ -1,0 +1,50 @@
+easyblock = 'CMakeMake'
+
+name = 'deal.II'
+version = '9.4.0'
+
+homepage = 'http://www.dealii.org/'
+description = """A C++ software library supporting the creation of finite element codes and an open community of users
+ and developers."""
+
+toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'usempi': True, 'pic': True, 'strict': True}
+
+source_urls = [
+    'https://www.dealii.org/downloads/',
+    ]
+sources = ['dealii-%(version)s.tar.gz']
+checksums = ['238677006cd9173658e5b69cdd1861f800556982db6005a3cc5eb8329cc1e36c']
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+]
+
+dependencies = [
+    ('METIS', '5.1.0'),
+    ('occt', '7.5.0p1'),
+    ('p4est', '2.3.3'),
+    ('SUNDIALS', '5.8.0'),
+    ('Trilinos', '13.2.0'),
+    ('TXR', '273'),
+]
+
+preconfigopts = """sed -i 's/make_quicktest("affinity/#/' ../dealii-%(version)s/tests/quick_tests/CMakeLists.txt && """
+
+configopts = '-DDEAL_II_WITH_MPI=ON '
+configopts += '-DDEAL_II_HAVE_USABLE_FLAGS_RELEASE=ON '
+configopts += '-DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTMETIS '
+configopts += '-DDEAL_II_WITH_OPENCASCADE=ON -DOPENCASCADE_DIR=$EBROOTOCCT '
+configopts += '-DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST '
+configopts += '-DDEAL_II_WITH_SCALAPACK=ON -DSCALAPACK_DIR=$EBROOTSCALAPACK -DSCALAPACK_LIBRARIES="$LIBSCALAPACK -lm" '
+configopts += '-DDEAL_II_WITH_SUNDIALS=ON -DSUNDIALS_DIR=$EBROOTSUNDIALS '
+configopts += '-DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS '
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': [('lib/libdeal_II.so')],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-iomkl-2021a.eb
+++ b/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-iomkl-2021a.eb
@@ -1,0 +1,50 @@
+easyblock = 'CMakeMake'
+
+name = 'deal.II'
+version = '9.4.0'
+
+homepage = 'http://www.dealii.org/'
+description = """A C++ software library supporting the creation of finite element codes and an open community of users
+ and developers."""
+
+toolchain = {'name': 'iomkl', 'version': '2021a'}
+toolchainopts = {'usempi': True, 'pic': True, 'strict': True}
+
+source_urls = ['https://www.dealii.org/downloads/']
+sources = ['dealii-%(version)s.tar.gz']
+checksums = ['238677006cd9173658e5b69cdd1861f800556982db6005a3cc5eb8329cc1e36c']
+
+builddependencies = [
+    ('CMake', '3.20.1'),
+]
+
+dependencies = [
+    ('METIS', '5.1.0'),
+    ('occt', '7.5.0p1'),
+    ('p4est', '2.3.2'),
+    ('SUNDIALS', '5.8.0'),
+    ('Trilinos', '13.2.0'),
+    ('TXR', '273'),
+]
+
+preconfigopts = """sed -i 's/make_quicktest("affinity/#/' ../dealii-%(version)s/tests/quick_tests/CMakeLists.txt && """
+
+configopts = '-DDEAL_II_WITH_MPI=ON '
+configopts += '-DDEAL_II_HAVE_USABLE_FLAGS_RELEASE=ON '
+configopts += '-DDEAL_II_WITH_METIS=ON -DMETIS_DIR=$EBROOTMETIS '
+configopts += '-DDEAL_II_WITH_OPENCASCADE=ON -DOPENCASCADE_DIR=$EBROOTOCCT '
+configopts += '-DDEAL_II_WITH_P4EST=ON -DP4EST_DIR=$EBROOTP4EST '
+configopts += '-DDEAL_II_WITH_SUNDIALS=ON -DSUNDIALS_DIR=$EBROOTSUNDIALS '
+configopts += '-DDEAL_II_WITH_TRILINOS=ON -DTRILINOS_DIR=$EBROOTTRILINOS '
+# latest develop fails to build with TBB on
+configopts += '-DDEAL_II_WITH_TBB=OFF '
+configopts += '-DLAPACK_LIBRARIES:STRING="-mkl -fuse-ld=bfd" '
+
+runtest = 'test'
+
+sanity_check_paths = {
+    'files': [('lib/libdeal_II.so')],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-iomkl-2021a.eb
+++ b/easybuild/easyconfigs/d/deal.II/deal.II-9.4.0-iomkl-2021a.eb
@@ -27,6 +27,7 @@ dependencies = [
     ('TXR', '273'),
 ]
 
+# disable the affinity test, as it expects access to all cores
 preconfigopts = """sed -i 's/make_quicktest("affinity/#/' ../dealii-%(version)s/tests/quick_tests/CMakeLists.txt && """
 
 configopts = '-DDEAL_II_WITH_MPI=ON '


### PR DESCRIPTION
For INC1316343 - `deal.II-9.4.0-foss-2021a.eb` and `deal.II-9.4.0-iomkl-2021a.eb`

**PLEASE NOTE**

- The Graphblas compilation of SuiteSparse with the Intel toolchain ( `SuiteSparse-5.10.1-iomkl-2021a-METIS-5.1.0.eb` ) consumes vast amounts of RAM - potentially all of what it detects available. Removing the unroll option made no significant change to this, nor did restricting paralellism. 
- Accordingly, to build this, I issued the $ARCH_build.sh scripts with --mem 125g. 

* [x] Assigned to reviewer

Default:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

