### PR TITLE
Fix EPACTS file generation

### DIFF
--- a/easybuild/easyconfigs/e/EPACTS/EPACTS-3.3.2-foss-2021a.eb
+++ b/easybuild/easyconfigs/e/EPACTS/EPACTS-3.3.2-foss-2021a.eb
@@ -14,11 +14,13 @@ source_urls = ['https://github.com/statgen/EPACTS/archive/']
 sources = ['v%(version)s.tar.gz']
 patches = [
     'EPACTS-3.3.2_isnam.patch',
+    'EPACTS-3.3.2_prologue.patch',
     ('EPACTS-3.3.2_R_isnam.patch', 1),
 ]
 checksums = [
     'e389a33cbb82aaab39fef07c2fb14477f90600e46180148df7ebaa4495e8cbe7',  # v3.3.2.tar.gz
     'f56027301fc304a9c9ad29045cd40c9d47dd70933a769b6251fcff372717fc08',  # EPACTS-3.3.2_isnam.patch
+    'a3cfcbd4044202d17810b935b9f43c2ed2fc8185a508b602c4da3ef5531fa7ea',  # EPACTS-3.3.2_prologue.patch
     '55f62c81498485529318e048ac6daa8c59229eb730889deed210ff64325eadaf',  # EPACTS-3.3.2_R_isnam.patch
 ]
 

--- a/easybuild/easyconfigs/e/EPACTS/EPACTS-3.3.2_prologue.patch
+++ b/easybuild/easyconfigs/e/EPACTS/EPACTS-3.3.2_prologue.patch
@@ -1,0 +1,11 @@
+https://github.com/statgen/EPACTS/pull/27
+--- data/prologue.ps	2022-12-12 10:09:41.610482000 +0000
++++ data/prologue.ps	2022-12-12 10:10:07.136069318 +0000
+@@ -48,6 +48,7 @@
+ % Default Line Types
+ /LTw {PL [] 1 setgray} def
+ /LTb {BL [] LCb DL} def
++/LTB {LTb} def
+ /LTa {AL [1 udl mul 2 udl mul] 0 setdash LCa setrgbcolor} def
+ /LT0 {PL [] LC0 DL} def
+ /LT1 {PL [4 dl1 2 dl2] LC1 DL} def


### PR DESCRIPTION
For INC1329616 - `EPACTS-3.3.2-foss-2021a.eb` (rebuild)

* [x] Assigned to reviewers (usually everyone in apps team)

Default:
* [x] EL8-icelake
* [x] EL8-cascadelake
* [x] EL8-haswell

