### PR TITLE
use bfd linker

### DIFF
--- a/easybuild/easyconfigs/a/AUTO-07p/AUTO-07p-0.9.3-foss-2021a.eb
+++ b/easybuild/easyconfigs/a/AUTO-07p/AUTO-07p-0.9.3-foss-2021a.eb
@@ -9,6 +9,7 @@ in ordinary differential equations originally written in 1980 and widely used in
 systems community."""
 
 toolchain = {'name': 'foss', 'version': '2021a'}
+toolchainopts = {'extra_cflags': '-fuse-ld=bfd', 'extra_fflags': '-fuse-ld=bfd'}
 
 source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s']
 sources = ['auto-%(version)s.tar.gz']


### PR DESCRIPTION
This changes the internal build files the AUTO-7P uses to build during operation. I've manually changed the files in our install, so this does not need rebuilding.